### PR TITLE
feat: add vehicle portal for fleet management

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -7,6 +7,9 @@ import eslintConfigPrettier from "eslint-config-prettier/flat";
 
 export default defineConfig([
   {
+    ignores: ['.angular/**', 'node_modules/**', 'dist/**'],
+  },
+  {
     files: ["**/*.{js,mjs,cjs,ts,mts,cts}"],
     plugins: { js },
     extends: ["js/recommended"],

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -46,6 +46,14 @@ export const routes: Routes = [
     title: 'Inventory | Cue RMS',
   },
   {
+    path: 'vehicles',
+    loadComponent: () =>
+      import(
+        './vehicles/vehicle-portal-component/vehicle-portal-component'
+      ).then((m) => m.VehiclePortalComponent),
+    title: 'Vehicles | Cue RMS',
+  },
+  {
     path: 'clashes',
     loadComponent: () =>
       import('./clashes/clashes-component/clashes-component').then(

--- a/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.html
@@ -5,7 +5,7 @@
 
       <article *ngIf="article">
         <h1 class="title">{{ article.title }}</h1>
-        <div class="meta">Updated {{ article.updatedAt | date: "medium" }}</div>
+        <div class="meta">Updated {{ article.updated_at | date: "medium" }}</div>
 
         <!-- For simplicity, article.body is markdown-ish raw text. Replace with markdown renderer if desired -->
         <div class="body" [innerHTML]="article.body"></div>

--- a/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.html
@@ -11,8 +11,8 @@
             <p class="kb-card-excerpt">{{ a.excerpt }}</p>
             <div class="kb-card-meta">
               <small *ngIf="a.tags?.length">{{ a.tags?.join(" • ") }}</small>
-              <small *ngIf="a.updatedAt">
-                — {{ a.updatedAt | date: "mediumDate" }}</small
+              <small *ngIf="a.updated_at">
+                — {{ a.updated_at | date: "mediumDate" }}</small
               >
             </div>
           </a>

--- a/src/app/shared/main-navigation-component/main-navigation-component.html
+++ b/src/app/shared/main-navigation-component/main-navigation-component.html
@@ -6,6 +6,7 @@
     <li><a routerLink="/crew">Crew</a></li>
     <li><a routerLink="/crew-schedule">Scheduler</a></li>
     <li><a routerLink="/inventory">Inventory</a></li>
+    <li><a routerLink="/vehicles">Vehicles</a></li>
     <li><a routerLink="/clashes">Clashes</a></li>
     <li><a routerLink="/calendar">Calendar</a></li>
     <li><a routerLink="/reporting">Reporting</a></li>

--- a/src/app/vehicles/models/vehicle.model.ts
+++ b/src/app/vehicles/models/vehicle.model.ts
@@ -1,0 +1,36 @@
+export type VehicleStatus = 'active' | 'sold' | 'archived';
+
+export interface VehicleDetails {
+  purchaseDate: string;
+  vin: string;
+  engine: string;
+  chassis: string;
+  odometer: string;
+  fuelType: string;
+  transmission: string;
+  grossVehicleMass: string;
+  notes: string;
+}
+
+export interface MaintenanceRecord {
+  id: string;
+  date: string;
+  enteredBy: string;
+  work: string;
+  odoReading: string;
+  performedAt: string;
+  outcome: string;
+  cost: string;
+  notes: string;
+  locked: boolean;
+}
+
+export interface Vehicle {
+  id: string;
+  location: string;
+  name: string;
+  licensePlate: string;
+  status: VehicleStatus;
+  details: VehicleDetails;
+  maintenance: MaintenanceRecord[];
+}

--- a/src/app/vehicles/services/vehicle-data.service.ts
+++ b/src/app/vehicles/services/vehicle-data.service.ts
@@ -1,0 +1,351 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { MaintenanceRecord, Vehicle, VehicleStatus } from '../models/vehicle.model';
+
+export interface VehicleInput {
+  location: string;
+  name: string;
+  licensePlate: string;
+  status?: VehicleStatus;
+  details?: Partial<Vehicle['details']>;
+  maintenance?: MaintenanceRecord[];
+}
+
+export interface CsvImportResult {
+  added: number;
+  skipped: number;
+  errors: string[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class VehicleDataService {
+  private readonly storageKey = 'vehicle-portal-data';
+  private readonly vehiclesSubject = new BehaviorSubject<Vehicle[]>(
+    this.loadFromStorage(),
+  );
+
+  readonly vehicles$ = this.vehiclesSubject.asObservable();
+
+  addVehicle(payload: VehicleInput): Vehicle {
+    const vehicles = this.cloneVehicles();
+    const vehicle: Vehicle = {
+      id: this.createId(),
+      location: payload.location.trim(),
+      name: payload.name.trim(),
+      licensePlate: payload.licensePlate.trim().toUpperCase(),
+      status: payload.status ?? 'active',
+      details: {
+        purchaseDate: payload.details?.purchaseDate ?? '',
+        vin: payload.details?.vin ?? '',
+        engine: payload.details?.engine ?? '',
+        chassis: payload.details?.chassis ?? '',
+        odometer: payload.details?.odometer ?? '',
+        fuelType: payload.details?.fuelType ?? '',
+        transmission: payload.details?.transmission ?? '',
+        grossVehicleMass: payload.details?.grossVehicleMass ?? '',
+        notes: payload.details?.notes ?? '',
+      },
+      maintenance: payload.maintenance ?? [],
+    };
+
+    vehicles.push(vehicle);
+    this.updateVehicles(vehicles);
+    return vehicle;
+  }
+
+  updateVehicle(id: string, updater: (vehicle: Vehicle) => Vehicle): void {
+    const vehicles = this.cloneVehicles();
+    const index = vehicles.findIndex((vehicle) => vehicle.id === id);
+    if (index === -1) {
+      return;
+    }
+
+    vehicles[index] = updater(vehicles[index]);
+    this.updateVehicles(vehicles);
+  }
+
+  removeVehicle(id: string): void {
+    const vehicles = this.cloneVehicles().filter((vehicle) => vehicle.id !== id);
+    this.updateVehicles(vehicles);
+  }
+
+  markVehicleStatus(id: string, status: VehicleStatus): void {
+    this.updateVehicle(id, (vehicle) => ({
+      ...vehicle,
+      status,
+    }));
+  }
+
+  addMaintenanceRecord(id: string, record: Omit<MaintenanceRecord, 'id'>): void {
+    const newRecord: MaintenanceRecord = {
+      ...record,
+      id: this.createId(),
+    };
+
+    this.updateVehicle(id, (vehicle) => ({
+      ...vehicle,
+      maintenance: [newRecord, ...vehicle.maintenance],
+    }));
+  }
+
+  updateMaintenanceRecord(
+    vehicleId: string,
+    recordId: string,
+    updater: (record: MaintenanceRecord) => MaintenanceRecord,
+  ): void {
+    this.updateVehicle(vehicleId, (vehicle) => ({
+      ...vehicle,
+      maintenance: vehicle.maintenance.map((record) =>
+        record.id === recordId ? updater(record) : record,
+      ),
+    }));
+  }
+
+  replaceAll(vehicles: Vehicle[]): void {
+    this.updateVehicles(this.clone(vehicles));
+  }
+
+  async importCsv(file: File): Promise<CsvImportResult> {
+    const text = await file.text();
+    const { vehicles, skipped, errors } = this.parseCsv(text);
+    if (vehicles.length === 0) {
+      return { added: 0, skipped, errors };
+    }
+
+    const existing = this.cloneVehicles();
+    this.updateVehicles([...existing, ...vehicles]);
+    return { added: vehicles.length, skipped, errors };
+  }
+
+  toggleMaintenanceLock(vehicleId: string, recordId: string): void {
+    this.updateMaintenanceRecord(vehicleId, recordId, (record) => ({
+      ...record,
+      locked: !record.locked,
+    }));
+  }
+
+  private cloneVehicles(): Vehicle[] {
+    return this.clone(this.vehiclesSubject.value);
+  }
+
+  private updateVehicles(vehicles: Vehicle[]): void {
+    this.vehiclesSubject.next(vehicles);
+    this.persistToStorage(vehicles);
+  }
+
+  private clone<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+  }
+
+  private loadFromStorage(): Vehicle[] {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return this.sampleVehicles();
+    }
+
+    const raw = window.localStorage.getItem(this.storageKey);
+    if (!raw) {
+      return this.sampleVehicles();
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Vehicle[];
+      if (!Array.isArray(parsed)) {
+        return this.sampleVehicles();
+      }
+      return parsed;
+    } catch (error) {
+      console.warn('Failed to parse stored vehicles', error);
+      return this.sampleVehicles();
+    }
+  }
+
+  private persistToStorage(vehicles: Vehicle[]): void {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+
+    window.localStorage.setItem(this.storageKey, JSON.stringify(vehicles));
+  }
+
+  private parseCsv(text: string): {
+    vehicles: Vehicle[];
+    skipped: number;
+    errors: string[];
+  } {
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    if (lines.length < 2) {
+      return { vehicles: [], skipped: 0, errors: ['No data rows found.'] };
+    }
+
+    const headers = this.normaliseHeaderLine(lines.shift()!);
+    const vehicles: Vehicle[] = [];
+    const errors: string[] = [];
+    let skipped = 0;
+
+    for (const [index, line] of lines.entries()) {
+      const values = this.splitCsvLine(line);
+      if (values.length !== headers.length) {
+        errors.push(
+          `Row ${index + 2} skipped: expected ${headers.length} columns but received ${values.length}.`,
+        );
+        skipped += 1;
+        continue;
+      }
+
+      const row = Object.fromEntries(
+        headers.map((header, headerIndex) => [header, values[headerIndex]]),
+      );
+
+      const name = row['vehicle']?.trim();
+      const licensePlate = row['license_plate']?.trim() || row['plate']?.trim();
+      if (!name || !licensePlate) {
+        errors.push(`Row ${index + 2} skipped: vehicle and license plate are required.`);
+        skipped += 1;
+        continue;
+      }
+
+      const status = this.parseStatus(row['status']);
+
+      vehicles.push({
+        id: this.createId(),
+        location: row['location']?.trim() ?? 'Unassigned',
+        name,
+        licensePlate: licensePlate.toUpperCase(),
+        status,
+        details: {
+          purchaseDate: row['purchase_date']?.trim() ?? '',
+          vin: row['vin']?.trim() ?? '',
+          engine: row['engine']?.trim() ?? '',
+          chassis: row['chassis']?.trim() ?? '',
+          odometer: row['odometer']?.trim() ?? '',
+          fuelType: row['fuel_type']?.trim() ?? '',
+          transmission: row['transmission']?.trim() ?? '',
+          grossVehicleMass: row['gross_vehicle_mass']?.trim() ?? row['gvm']?.trim() ?? '',
+          notes: row['notes']?.trim() ?? '',
+        },
+        maintenance: [],
+      });
+    }
+
+    return { vehicles, skipped, errors };
+  }
+
+  private normaliseHeaderLine(line: string): string[] {
+    return this.splitCsvLine(line).map((header) =>
+      header
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim()
+        .replace(/\s+/g, '_'),
+    );
+  }
+
+  private splitCsvLine(line: string): string[] {
+    const values: string[] = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i += 1) {
+      const char = line[i];
+      if (char === '"') {
+        if (inQuotes && line[i + 1] === '"') {
+          current += '"';
+          i += 1;
+          continue;
+        }
+        inQuotes = !inQuotes;
+        continue;
+      }
+
+      if (char === ',' && !inQuotes) {
+        values.push(current.trim());
+        current = '';
+        continue;
+      }
+
+      current += char;
+    }
+
+    values.push(current.trim());
+    return values;
+  }
+
+  private parseStatus(raw: string | undefined): VehicleStatus {
+    const value = raw?.toLowerCase() ?? '';
+    if (value === 'sold') {
+      return 'sold';
+    }
+    if (value === 'archived') {
+      return 'archived';
+    }
+    return 'active';
+  }
+
+  private createId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+    return Math.random().toString(36).slice(2, 11);
+  }
+
+  private sampleVehicles(): Vehicle[] {
+    const now = new Date().toISOString().split('T')[0];
+    return [
+      {
+        id: this.createId(),
+        location: 'Dunedin',
+        name: 'Hino Truck (Class 2)',
+        licensePlate: 'APQ960',
+        status: 'active',
+        details: {
+          purchaseDate: now,
+          vin: 'JN1WY26U5XM123456',
+          engine: 'Hino J08E',
+          chassis: 'TRK1234567',
+          odometer: '205,418 km',
+          fuelType: 'Diesel',
+          transmission: 'Automatic',
+          grossVehicleMass: '12,000 kg',
+          notes: 'Tail lift serviced in 2024.',
+        },
+        maintenance: [
+          {
+            id: this.createId(),
+            date: '2025-02-20',
+            enteredBy: 'Hollie Walsh',
+            work: 'COF & maintenance',
+            odoReading: '205,000',
+            performedAt: 'Vinz',
+            outcome: 'Passed',
+            cost: '$650.00',
+            notes: 'Replaced wiper blades and adjusted brake bias.',
+            locked: false,
+          },
+        ],
+      },
+      {
+        id: this.createId(),
+        location: 'Christchurch',
+        name: 'Corolla',
+        licensePlate: 'FTN850',
+        status: 'active',
+        details: {
+          purchaseDate: '2022-10-12',
+          vin: 'JTDBR32E330076543',
+          engine: '1.8L Petrol',
+          chassis: 'BR32E330076543',
+          odometer: '98,214 km',
+          fuelType: 'Petrol',
+          transmission: 'Automatic',
+          grossVehicleMass: '1,600 kg',
+          notes: 'Assigned to Christchurch operations team.',
+        },
+        maintenance: [],
+      },
+    ];
+  }
+}

--- a/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.html
+++ b/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.html
@@ -1,0 +1,366 @@
+<ui-shell>
+  <content>
+    <div class="vehicle-portal">
+      <header class="page-header">
+        <div>
+          <h1>Vehicle Fleet Portal</h1>
+          <p>Track company vehicles, log maintenance and keep the fleet in sync.</p>
+        </div>
+        <div class="page-header__controls">
+          <div class="stats">
+            <div class="stat">
+              <span class="stat__label">Active</span>
+              <span class="stat__value">{{ activeVehicles() }}</span>
+            </div>
+            <div class="stat">
+              <span class="stat__label">Sold</span>
+              <span class="stat__value">{{ soldVehicles() }}</span>
+            </div>
+            <div class="stat">
+              <span class="stat__label">Archived</span>
+              <span class="stat__value">{{ archivedVehicles() }}</span>
+            </div>
+          </div>
+          <div class="auth-selector">
+            <label for="authLevel">Auth level</label>
+            <select
+              id="authLevel"
+              [value]="authLevel()"
+              (change)="handleAuthLevelChange($event)"
+            >
+              <option value="1">Admin (1)</option>
+              <option value="2">Standard (2)</option>
+            </select>
+          </div>
+        </div>
+      </header>
+
+      <section class="import">
+        <label class="import__label" for="vehicleCsv">Import vehicle spreadsheet (CSV)</label>
+        <input id="vehicleCsv" type="file" accept=".csv" (change)="importCsv($event)" />
+        <p class="import__summary" *ngIf="csvImportSummary()">{{ csvImportSummary() }}</p>
+        <ul class="import__errors" *ngIf="csvImportErrors().length">
+          <li *ngFor="let error of csvImportErrors()">{{ error }}</li>
+        </ul>
+      </section>
+
+      <div class="portal-grid">
+        <section class="panel vehicle-list">
+          <header class="panel__header">
+            <h2>Vehicles</h2>
+          </header>
+          <div class="table-wrapper">
+            <table class="vehicle-table">
+              <thead>
+                <tr>
+                  <th>Vehicle</th>
+                  <th>Plate</th>
+                  <th>Location</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  *ngFor="let vehicle of vehicles(); trackBy: trackByVehicleId"
+                  (click)="selectVehicle(vehicle)"
+                  [class.selected]="selectedVehicle()?.id === vehicle.id"
+                >
+                  <td>
+                    <div class="vehicle-name">{{ vehicle.name }}</div>
+                    <div class="vehicle-meta">Added {{ vehicle.details.purchaseDate || '—' }}</div>
+                  </td>
+                  <td>
+                    <span class="plate">{{ vehicle.licensePlate }}</span>
+                  </td>
+                  <td>{{ vehicle.location }}</td>
+                  <td>
+                    <span [ngClass]="['status-pill', 'status-' + vehicle.status]">{{ vehicle.status }}</span>
+                  </td>
+                </tr>
+                <tr *ngIf="!vehicles().length">
+                  <td colspan="4" class="empty">No vehicles loaded yet.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <form class="panel__form" [formGroup]="newVehicleForm" (ngSubmit)="addVehicle()">
+            <h3>Add a vehicle</h3>
+            <div class="form-grid">
+              <label>
+                <span>Vehicle name</span>
+                <input type="text" formControlName="name" placeholder="e.g. Hino Truck" />
+              </label>
+              <label>
+                <span>License plate</span>
+                <input type="text" formControlName="licensePlate" placeholder="e.g. ABC123" />
+              </label>
+              <label>
+                <span>Location</span>
+                <input type="text" formControlName="location" placeholder="e.g. Dunedin" />
+              </label>
+              <label>
+                <span>Purchase date</span>
+                <input type="date" formControlName="purchaseDate" />
+              </label>
+              <label>
+                <span>VIN</span>
+                <input type="text" formControlName="vin" />
+              </label>
+              <label>
+                <span>Engine</span>
+                <input type="text" formControlName="engine" />
+              </label>
+              <label>
+                <span>Chassis</span>
+                <input type="text" formControlName="chassis" />
+              </label>
+              <label>
+                <span>Odometer</span>
+                <input type="text" formControlName="odometer" />
+              </label>
+              <label>
+                <span>Fuel type</span>
+                <input type="text" formControlName="fuelType" />
+              </label>
+              <label>
+                <span>Transmission</span>
+                <input type="text" formControlName="transmission" />
+              </label>
+              <label>
+                <span>Gross vehicle mass</span>
+                <input type="text" formControlName="grossVehicleMass" />
+              </label>
+              <label class="wide">
+                <span>Notes</span>
+                <textarea rows="2" formControlName="notes"></textarea>
+              </label>
+              <label>
+                <span>Status</span>
+                <select formControlName="status">
+                  <option value="active">Active</option>
+                  <option value="sold">Sold</option>
+                  <option value="archived">Archived</option>
+                </select>
+              </label>
+            </div>
+            <button type="submit" class="primary">Add vehicle</button>
+          </form>
+        </section>
+
+        <section class="panel vehicle-details" *ngIf="selectedVehicle(); else noSelection">
+          <header class="panel__header">
+            <div>
+              <h2>{{ selectedVehicle()?.name }}</h2>
+              <p class="subtitle">{{ selectedVehicle()?.licensePlate }} • {{ selectedVehicle()?.location }}</p>
+            </div>
+            <div class="status-actions">
+              <button type="button" (click)="markVehicleStatus('active')" [disabled]="selectedVehicle()?.status === 'active'">
+                Mark active
+              </button>
+              <button type="button" (click)="markVehicleStatus('sold')" [disabled]="selectedVehicle()?.status === 'sold'">
+                Mark sold
+              </button>
+              <button type="button" (click)="markVehicleStatus('archived')" [disabled]="selectedVehicle()?.status === 'archived'">
+                Archive
+              </button>
+            </div>
+          </header>
+
+          <form class="panel__form" [formGroup]="vehicleDetailsForm" (ngSubmit)="saveVehicleDetails()">
+            <h3>Vehicle details</h3>
+            <div class="form-grid">
+              <label>
+                <span>Vehicle name</span>
+                <input type="text" formControlName="name" />
+              </label>
+              <label>
+                <span>License plate</span>
+                <input type="text" formControlName="licensePlate" [readonly]="!canEditCoreDetails()" />
+              </label>
+              <label>
+                <span>Location</span>
+                <input type="text" formControlName="location" />
+              </label>
+              <label>
+                <span>Purchase date</span>
+                <input type="date" formControlName="purchaseDate" [readonly]="!canEditCoreDetails()" />
+              </label>
+              <label>
+                <span>VIN</span>
+                <input type="text" formControlName="vin" [readonly]="!canEditCoreDetails()" />
+              </label>
+              <label>
+                <span>Engine</span>
+                <input type="text" formControlName="engine" />
+              </label>
+              <label>
+                <span>Chassis</span>
+                <input type="text" formControlName="chassis" />
+              </label>
+              <label>
+                <span>Odometer</span>
+                <input type="text" formControlName="odometer" />
+              </label>
+              <label>
+                <span>Fuel type</span>
+                <input type="text" formControlName="fuelType" />
+              </label>
+              <label>
+                <span>Transmission</span>
+                <input type="text" formControlName="transmission" />
+              </label>
+              <label>
+                <span>Gross vehicle mass</span>
+                <input type="text" formControlName="grossVehicleMass" />
+              </label>
+              <label class="wide">
+                <span>Notes</span>
+                <textarea rows="3" formControlName="notes"></textarea>
+              </label>
+              <label>
+                <span>Status</span>
+                <select formControlName="status">
+                  <option value="active">Active</option>
+                  <option value="sold">Sold</option>
+                  <option value="archived">Archived</option>
+                </select>
+              </label>
+            </div>
+            <button type="submit" class="primary">Save changes</button>
+          </form>
+
+          <section class="maintenance">
+            <header class="maintenance__header">
+              <div>
+                <h3>Maintenance log</h3>
+                <p>Lock entries to prevent non-admin edits.</p>
+              </div>
+            </header>
+
+            <form class="maintenance__form" [formGroup]="maintenanceForm" (ngSubmit)="addMaintenance()">
+              <div class="form-grid">
+                <label>
+                  <span>Date</span>
+                  <input type="date" formControlName="date" />
+                </label>
+                <label>
+                  <span>Entered by</span>
+                  <input type="text" formControlName="enteredBy" />
+                </label>
+                <label>
+                  <span>Work</span>
+                  <input type="text" formControlName="work" />
+                </label>
+                <label>
+                  <span>ODO reading</span>
+                  <input type="text" formControlName="odoReading" />
+                </label>
+                <label>
+                  <span>Where</span>
+                  <input type="text" formControlName="performedAt" />
+                </label>
+                <label>
+                  <span>Outcome</span>
+                  <input type="text" formControlName="outcome" />
+                </label>
+                <label>
+                  <span>Cost</span>
+                  <input type="text" formControlName="cost" />
+                </label>
+                <label class="wide">
+                  <span>Notes</span>
+                  <textarea rows="2" formControlName="notes"></textarea>
+                </label>
+              </div>
+              <button type="submit">Add maintenance record</button>
+            </form>
+
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Entered by</th>
+                    <th>Work</th>
+                    <th>ODO</th>
+                    <th>Where</th>
+                    <th>Outcome</th>
+                    <th>Cost</th>
+                    <th>Notes</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <ng-container
+                    *ngFor="
+                      let record of selectedVehicle()?.maintenance;
+                      trackBy: trackByMaintenance
+                    "
+                  >
+                    <ng-container *ngIf="editingMaintenanceId() === record.id; else viewRow">
+                      <tr class="editing">
+                        <td><input type="date" [formControl]="maintenanceEditForm.controls.date" /></td>
+                        <td><input type="text" [formControl]="maintenanceEditForm.controls.enteredBy" /></td>
+                        <td><input type="text" [formControl]="maintenanceEditForm.controls.work" /></td>
+                        <td><input type="text" [formControl]="maintenanceEditForm.controls.odoReading" /></td>
+                        <td><input type="text" [formControl]="maintenanceEditForm.controls.performedAt" /></td>
+                        <td><input type="text" [formControl]="maintenanceEditForm.controls.outcome" /></td>
+                        <td><input type="text" [formControl]="maintenanceEditForm.controls.cost" /></td>
+                        <td><textarea rows="2" [formControl]="maintenanceEditForm.controls.notes"></textarea></td>
+                        <td class="actions">
+                          <button type="button" (click)="saveMaintenanceEdit(record)">Save</button>
+                          <button type="button" class="ghost" (click)="cancelMaintenanceEdit()">Cancel</button>
+                        </td>
+                      </tr>
+                    </ng-container>
+                    <ng-template #viewRow>
+                      <tr [ngClass]="maintenanceRowClass(record)">
+                        <td>{{ record.date }}</td>
+                        <td>{{ record.enteredBy }}</td>
+                        <td>{{ record.work }}</td>
+                        <td>{{ record.odoReading }}</td>
+                        <td>{{ record.performedAt }}</td>
+                        <td>{{ record.outcome }}</td>
+                        <td>{{ record.cost }}</td>
+                        <td>{{ record.notes }}</td>
+                        <td class="actions">
+                          <button
+                            type="button"
+                            (click)="startEditMaintenance(record)"
+                            [disabled]="!canEditMaintenance(record)"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            *ngIf="authLevel() === 1"
+                            (click)="toggleMaintenanceLock(record)"
+                          >
+                            {{ record.locked ? 'Unlock' : 'Lock' }}
+                          </button>
+                        </td>
+                      </tr>
+                    </ng-template>
+                  </ng-container>
+                  <tr *ngIf="!selectedVehicle()?.maintenance?.length">
+                    <td colspan="9" class="empty">No maintenance recorded yet.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </section>
+
+        <ng-template #noSelection>
+          <section class="panel vehicle-details empty-state">
+            <header class="panel__header">
+              <h2>Select a vehicle</h2>
+            </header>
+            <p>Choose a vehicle from the list to review its details and maintenance history.</p>
+          </section>
+        </ng-template>
+      </div>
+    </div>
+  </content>
+</ui-shell>

--- a/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.scss
+++ b/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.scss
@@ -1,0 +1,387 @@
+@use '../../../style/colors.scss' as colors;
+@use '../../../style/effects.scss' as effects;
+@use '../../../style/buttons.scss' as buttons;
+
+.vehicle-portal {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  color: colors.$off-black;
+
+  h1,
+  h2,
+  h3 {
+    font-weight: 600;
+    color: colors.$primary-color;
+  }
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+
+  p {
+    margin-top: 0.25rem;
+    color: rgba(colors.$off-black, 0.75);
+  }
+}
+
+.page-header__controls {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+
+  .stat {
+    background: white;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    @include effects.box-shadow;
+    min-width: 120px;
+
+    .stat__label {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      color: rgba(colors.$off-black, 0.6);
+      letter-spacing: 0.05em;
+    }
+
+    .stat__value {
+      display: block;
+      font-size: 1.75rem;
+      font-weight: 600;
+      color: colors.$secondary-color;
+    }
+  }
+}
+
+.auth-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+
+  select {
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(colors.$primary-color, 0.2);
+    min-width: 160px;
+  }
+}
+
+.import {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  @include effects.box-shadow;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+
+  input[type='file'] {
+    padding: 0.5rem;
+    border: 1px dashed rgba(colors.$primary-color, 0.3);
+    border-radius: 0.75rem;
+  }
+
+  .import__summary {
+    font-size: 0.9rem;
+    color: colors.$secondary-color;
+  }
+
+  .import__errors {
+    list-style: disc;
+    padding-left: 1.5rem;
+    color: #c93131;
+    font-size: 0.85rem;
+  }
+}
+
+.portal-grid {
+  display: grid;
+  grid-template-columns: minmax(320px, 1.05fr) minmax(400px, 1.5fr);
+  gap: 2rem;
+}
+
+.panel {
+  background: white;
+  border-radius: 1rem;
+  @include effects.box-shadow;
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+}
+
+.panel__header {
+  padding: 1.25rem 1.5rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  .subtitle {
+    color: rgba(colors.$off-black, 0.65);
+    font-size: 0.95rem;
+    margin-top: 0.35rem;
+  }
+}
+
+.panel__form {
+  padding: 1.5rem;
+  border-top: 1px solid rgba(colors.$primary-color, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  h3 {
+    font-size: 1.1rem;
+  }
+
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem 1rem;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+
+      input,
+      textarea,
+      select {
+        padding: 0.6rem 0.75rem;
+        border-radius: 0.6rem;
+        border: 1px solid rgba(colors.$primary-color, 0.2);
+        background: rgba(colors.$off-white, 0.65);
+        font-size: 0.95rem;
+      }
+
+      textarea {
+        resize: vertical;
+      }
+
+      &.wide {
+        grid-column: 1 / -1;
+      }
+    }
+  }
+
+  button {
+    align-self: flex-start;
+    @include buttons.primary-button;
+  }
+}
+
+.panel.vehicle-list {
+  .table-wrapper {
+    padding: 1rem 1.5rem 0;
+  }
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+
+  thead {
+    background: rgba(colors.$primary-color, 0.04);
+
+    th {
+      text-align: left;
+      padding: 0.75rem 1rem;
+      font-weight: 600;
+      color: colors.$primary-color;
+    }
+  }
+
+  tbody {
+    tr {
+      border-top: 1px solid rgba(colors.$primary-color, 0.05);
+      transition: background 0.2s ease;
+
+      &.selected {
+        background: rgba(colors.$secondary-color, 0.12);
+      }
+
+      &:hover {
+        background: rgba(colors.$secondary-color, 0.08);
+      }
+
+      &.editing {
+        background: rgba(colors.$secondary-color, 0.1);
+      }
+
+      &.locked {
+        background: rgba(colors.$primary-color, 0.06);
+      }
+
+      &.failed {
+        background: rgba(201, 49, 49, 0.08);
+      }
+
+      td {
+        padding: 0.75rem 1rem;
+        vertical-align: top;
+      }
+
+      .actions {
+        display: flex;
+        gap: 0.5rem;
+        justify-content: flex-end;
+
+        button {
+          padding: 0.4rem 0.8rem;
+          border-radius: 0.5rem;
+          border: 1px solid rgba(colors.$primary-color, 0.2);
+          background: white;
+          cursor: pointer;
+
+          &.ghost {
+            background: transparent;
+          }
+        }
+      }
+    }
+
+    .empty {
+      text-align: center;
+      padding: 2rem 1rem;
+      color: rgba(colors.$off-black, 0.6);
+    }
+  }
+}
+
+.vehicle-table tbody tr:hover {
+  cursor: pointer;
+}
+
+.vehicle-name {
+  font-weight: 600;
+}
+
+.vehicle-meta {
+  font-size: 0.8rem;
+  color: rgba(colors.$off-black, 0.6);
+}
+
+.plate {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(colors.$secondary-color, 0.15);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.4rem;
+  display: inline-block;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  text-transform: capitalize;
+  font-weight: 600;
+  font-size: 0.85rem;
+
+  &.status-active {
+    background: rgba(32, 166, 113, 0.15);
+    color: #1b7f57;
+  }
+
+  &.status-sold {
+    background: rgba(255, 166, 0, 0.15);
+    color: #b77900;
+  }
+
+  &.status-archived {
+    background: rgba(120, 120, 120, 0.18);
+    color: #555;
+  }
+}
+
+.status-actions {
+  display: flex;
+  gap: 0.5rem;
+
+  button {
+    padding: 0.5rem 1rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(colors.$primary-color, 0.2);
+    background: white;
+    cursor: pointer;
+    font-weight: 500;
+
+    &:hover:not(:disabled) {
+      background: rgba(colors.$secondary-color, 0.1);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.maintenance {
+  padding: 1.5rem;
+  border-top: 1px solid rgba(colors.$primary-color, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  .maintenance__form {
+    button {
+      align-self: flex-start;
+      @include buttons.secondary-button;
+    }
+  }
+}
+
+.empty-state {
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: rgba(colors.$off-black, 0.65);
+  min-height: 400px;
+  padding: 2rem;
+}
+
+@media (max-width: 1200px) {
+  .portal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .status-actions {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .vehicle-portal {
+    padding: 1.5rem;
+  }
+
+  .page-header {
+    flex-direction: column;
+  }
+
+  .page-header__controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.ts
+++ b/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.ts
@@ -1,0 +1,393 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  FormBuilder,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+import {
+  CsvImportResult,
+  VehicleDataService,
+} from '../services/vehicle-data.service';
+import {
+  MaintenanceRecord,
+  Vehicle,
+  VehicleStatus,
+} from '../models/vehicle.model';
+
+@Component({
+  selector: 'vehicle-portal-component',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, UiShellComponent],
+  templateUrl: './vehicle-portal-component.html',
+  styleUrl: './vehicle-portal-component.scss',
+})
+export class VehiclePortalComponent implements OnInit {
+  private readonly fb = inject(FormBuilder);
+  private readonly vehicleData = inject(VehicleDataService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  vehicles = signal<Vehicle[]>([]);
+  selectedVehicleId = signal<string | null>(null);
+  authLevel = signal<1 | 2>(2);
+
+  readonly selectedVehicle = computed(() =>
+    this.vehicles().find((vehicle) => vehicle.id === this.selectedVehicleId()) ??
+    null,
+  );
+
+  readonly activeVehicles = computed(() =>
+    this.vehicles().filter((vehicle) => vehicle.status === 'active').length,
+  );
+  readonly soldVehicles = computed(() =>
+    this.vehicles().filter((vehicle) => vehicle.status === 'sold').length,
+  );
+  readonly archivedVehicles = computed(() =>
+    this.vehicles().filter((vehicle) => vehicle.status === 'archived').length,
+  );
+
+  readonly newVehicleForm = this.fb.nonNullable.group({
+    location: ['', [Validators.required, Validators.maxLength(60)]],
+    name: ['', [Validators.required, Validators.maxLength(120)]],
+    licensePlate: ['', [Validators.required, Validators.maxLength(12)]],
+    purchaseDate: [''],
+    vin: [''],
+    engine: [''],
+    chassis: [''],
+    odometer: [''],
+    fuelType: [''],
+    transmission: [''],
+    grossVehicleMass: [''],
+    notes: [''],
+    status: this.fb.nonNullable.control<VehicleStatus>('active'),
+  });
+
+  readonly vehicleDetailsForm = this.fb.nonNullable.group({
+    location: ['', [Validators.required, Validators.maxLength(60)]],
+    name: ['', [Validators.required, Validators.maxLength(120)]],
+    licensePlate: ['', [Validators.required, Validators.maxLength(12)]],
+    purchaseDate: [''],
+    vin: [''],
+    engine: [''],
+    chassis: [''],
+    odometer: [''],
+    fuelType: [''],
+    transmission: [''],
+    grossVehicleMass: [''],
+    notes: [''],
+    status: this.fb.nonNullable.control<VehicleStatus>('active'),
+  });
+
+  readonly maintenanceForm = this.fb.nonNullable.group({
+    date: ['', Validators.required],
+    enteredBy: ['', Validators.required],
+    work: ['', Validators.required],
+    odoReading: [''],
+    performedAt: [''],
+    outcome: [''],
+    cost: [''],
+    notes: [''],
+  });
+
+  editingMaintenanceId = signal<string | null>(null);
+  maintenanceEditForm = this.fb.nonNullable.group({
+    date: ['', Validators.required],
+    enteredBy: ['', Validators.required],
+    work: ['', Validators.required],
+    odoReading: [''],
+    performedAt: [''],
+    outcome: [''],
+    cost: [''],
+    notes: [''],
+  });
+
+  csvImportSummary = signal<string>('');
+  csvImportErrors = signal<string[]>([]);
+
+  private readonly syncFormEffect = effect(() => {
+    const selected = this.selectedVehicle();
+    if (selected) {
+      this.vehicleDetailsForm.patchValue({
+        location: selected.location,
+        name: selected.name,
+        licensePlate: selected.licensePlate,
+        purchaseDate: selected.details.purchaseDate,
+        vin: selected.details.vin,
+        engine: selected.details.engine,
+        chassis: selected.details.chassis,
+        odometer: selected.details.odometer,
+        fuelType: selected.details.fuelType,
+        transmission: selected.details.transmission,
+        grossVehicleMass: selected.details.grossVehicleMass,
+        notes: selected.details.notes,
+        status: selected.status,
+      });
+    }
+  });
+
+  ngOnInit(): void {
+    this.vehicleData.vehicles$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((vehicles) => {
+        this.vehicles.set(vehicles);
+        if (vehicles.length > 0 && !this.selectedVehicleId()) {
+          this.selectedVehicleId.set(vehicles[0].id);
+        }
+        if (
+          vehicles.length > 0 &&
+          this.selectedVehicleId() &&
+          !vehicles.some((vehicle) => vehicle.id === this.selectedVehicleId())
+        ) {
+          this.selectedVehicleId.set(vehicles[0].id);
+        }
+      });
+  }
+
+  trackByVehicleId(_: number, vehicle: Vehicle): string {
+    return vehicle.id;
+  }
+
+  trackByMaintenance(_: number, record: MaintenanceRecord): string {
+    return record.id;
+  }
+
+  selectVehicle(vehicle: Vehicle): void {
+    this.selectedVehicleId.set(vehicle.id);
+  }
+
+  canEditCoreDetails(): boolean {
+    return this.authLevel() === 1;
+  }
+
+  canEditMaintenance(record: MaintenanceRecord): boolean {
+    if (this.authLevel() === 1) {
+      return true;
+    }
+    return !record.locked;
+  }
+
+  changeAuthLevel(level: '1' | '2'): void {
+    this.authLevel.set(level === '1' ? 1 : 2);
+  }
+
+  handleAuthLevelChange(event: Event): void {
+    const select = event.target as HTMLSelectElement | null;
+    if (!select) {
+      return;
+    }
+    const value = select.value === '1' ? '1' : '2';
+    this.changeAuthLevel(value);
+  }
+
+  addVehicle(): void {
+    if (this.newVehicleForm.invalid) {
+      this.newVehicleForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.newVehicleForm.getRawValue();
+    const vehicle = this.vehicleData.addVehicle({
+      location: value.location,
+      name: value.name,
+      licensePlate: value.licensePlate,
+      status: value.status,
+      details: {
+        purchaseDate: value.purchaseDate,
+        vin: value.vin,
+        engine: value.engine,
+        chassis: value.chassis,
+        odometer: value.odometer,
+        fuelType: value.fuelType,
+        transmission: value.transmission,
+        grossVehicleMass: value.grossVehicleMass,
+        notes: value.notes,
+      },
+    });
+
+    this.newVehicleForm.reset({
+      location: '',
+      name: '',
+      licensePlate: '',
+      purchaseDate: '',
+      vin: '',
+      engine: '',
+      chassis: '',
+      odometer: '',
+      fuelType: '',
+      transmission: '',
+      grossVehicleMass: '',
+      notes: '',
+      status: 'active',
+    });
+    this.selectedVehicleId.set(vehicle.id);
+  }
+
+  saveVehicleDetails(): void {
+    if (!this.selectedVehicle()) {
+      return;
+    }
+    if (this.vehicleDetailsForm.invalid) {
+      this.vehicleDetailsForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.vehicleDetailsForm.getRawValue();
+    this.vehicleData.updateVehicle(this.selectedVehicle()!.id, (vehicle) => ({
+      ...vehicle,
+      location: value.location,
+      name: value.name,
+      licensePlate: value.licensePlate.toUpperCase(),
+      status: value.status,
+      details: {
+        ...vehicle.details,
+        purchaseDate: value.purchaseDate,
+        vin: value.vin,
+        engine: value.engine,
+        chassis: value.chassis,
+        odometer: value.odometer,
+        fuelType: value.fuelType,
+        transmission: value.transmission,
+        grossVehicleMass: value.grossVehicleMass,
+        notes: value.notes,
+      },
+    }));
+  }
+
+  markVehicleStatus(status: VehicleStatus): void {
+    const vehicle = this.selectedVehicle();
+    if (!vehicle) {
+      return;
+    }
+    this.vehicleData.markVehicleStatus(vehicle.id, status);
+  }
+
+  addMaintenance(): void {
+    const vehicle = this.selectedVehicle();
+    if (!vehicle) {
+      return;
+    }
+    if (this.maintenanceForm.invalid) {
+      this.maintenanceForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.maintenanceForm.getRawValue();
+    this.vehicleData.addMaintenanceRecord(vehicle.id, {
+      date: value.date,
+      enteredBy: value.enteredBy,
+      work: value.work,
+      odoReading: value.odoReading,
+      performedAt: value.performedAt,
+      outcome: value.outcome,
+      cost: value.cost,
+      notes: value.notes,
+      locked: false,
+    });
+
+    this.maintenanceForm.reset({
+      date: '',
+      enteredBy: '',
+      work: '',
+      odoReading: '',
+      performedAt: '',
+      outcome: '',
+      cost: '',
+      notes: '',
+    });
+  }
+
+  startEditMaintenance(record: MaintenanceRecord): void {
+    if (!this.canEditMaintenance(record)) {
+      return;
+    }
+    this.editingMaintenanceId.set(record.id);
+    this.maintenanceEditForm.setValue({
+      date: record.date,
+      enteredBy: record.enteredBy,
+      work: record.work,
+      odoReading: record.odoReading,
+      performedAt: record.performedAt,
+      outcome: record.outcome,
+      cost: record.cost,
+      notes: record.notes,
+    });
+  }
+
+  cancelMaintenanceEdit(): void {
+    this.editingMaintenanceId.set(null);
+  }
+
+  saveMaintenanceEdit(record: MaintenanceRecord): void {
+    if (this.maintenanceEditForm.invalid) {
+      this.maintenanceEditForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.maintenanceEditForm.getRawValue();
+    this.vehicleData.updateMaintenanceRecord(
+      this.selectedVehicle()!.id,
+      record.id,
+      () => ({
+        ...record,
+        date: value.date,
+        enteredBy: value.enteredBy,
+        work: value.work,
+        odoReading: value.odoReading,
+        performedAt: value.performedAt,
+        outcome: value.outcome,
+        cost: value.cost,
+        notes: value.notes,
+      }),
+    );
+    this.editingMaintenanceId.set(null);
+  }
+
+  toggleMaintenanceLock(record: MaintenanceRecord): void {
+    const vehicle = this.selectedVehicle();
+    if (!vehicle) {
+      return;
+    }
+    if (this.authLevel() !== 1) {
+      return;
+    }
+    this.vehicleData.toggleMaintenanceLock(vehicle.id, record.id);
+  }
+
+  async importCsv(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const result: CsvImportResult = await this.vehicleData.importCsv(file);
+    const skippedText = result.skipped > 0 ? `, ${result.skipped} skipped` : '';
+    this.csvImportSummary.set(
+      `${result.added} vehicle${result.added === 1 ? '' : 's'} imported${skippedText}`,
+    );
+    this.csvImportErrors.set(result.errors);
+    input.value = '';
+  }
+
+  maintenanceRowClass(record: MaintenanceRecord): string {
+    const classes: string[] = [];
+    if (record.locked) {
+      classes.push('locked');
+    }
+    if (record.outcome.toLowerCase().includes('fail')) {
+      classes.push('failed');
+    }
+    return classes.join(' ');
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone vehicle portal with fleet metrics, add/edit forms, CSV import, and maintenance locking controls
- provide a vehicle data service with local storage persistence, CSV parsing, and starter sample records
- expose the new portal via navigation/routing and align lint/knowledge base templates for successful builds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd8a7b63d4832389a371e192a3265a