### PR TITLE
Add authenticated login flow and settings dashboard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,17 +1,26 @@
 import { Routes } from '@angular/router';
 import { HomeComponent } from './home/home-component/home-component';
 import { NotFoundComponent } from './shared/not-found-component/not-found-component';
+import { authGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
+  {
+    path: 'login',
+    loadComponent: () =>
+      import('./auth/login/login.component').then((m) => m.LoginComponent),
+    title: 'Sign in | Cue RMS',
+  },
   {
     path: '',
     component: HomeComponent,
     title: 'Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'home',
     component: HomeComponent,
     title: 'Cue rms',
+    canActivate: [authGuard],
   },
   {
     path: 'sales',
@@ -20,6 +29,7 @@ export const routes: Routes = [
         (m) => m.SalesComponent,
       ),
     title: 'Sales | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'crew',
@@ -28,6 +38,7 @@ export const routes: Routes = [
         (m) => m.CrewComponent,
       ),
     title: 'Crew | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'crew-schedule',
@@ -36,6 +47,7 @@ export const routes: Routes = [
         (m) => m.CrewScheduler,
       ),
     title: 'Scheduler | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'inventory',
@@ -44,6 +56,7 @@ export const routes: Routes = [
         (m) => m.InventoryComponent,
       ),
     title: 'Inventory | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'vehicles',
@@ -52,6 +65,7 @@ export const routes: Routes = [
         './vehicles/vehicle-portal-component/vehicle-portal-component'
       ).then((m) => m.VehiclePortalComponent),
     title: 'Vehicles | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'clashes',
@@ -60,6 +74,7 @@ export const routes: Routes = [
         (m) => m.ClashesComponent,
       ),
     title: 'Clashes | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'calendar',
@@ -68,6 +83,7 @@ export const routes: Routes = [
         (m) => m.CalendarComponent,
       ),
     title: 'Calendar | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'reporting',
@@ -76,6 +92,16 @@ export const routes: Routes = [
         (m) => m.ReportingComponent,
       ),
     title: 'Reporting | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
+    path: 'settings',
+    loadComponent: () =>
+      import('./settings/settings-dashboard/settings-dashboard.component').then(
+        (m) => m.SettingsDashboardComponent,
+      ),
+    title: 'Settings | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: 'kb',
@@ -84,6 +110,7 @@ export const routes: Routes = [
         (m) => m.KnowledgeBaseRoutes,
       ),
     title: 'KBase | Cue RMS',
+    canActivate: [authGuard],
   },
   {
     path: '**',

--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = async (_route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  await authService.ensureSessionResolved();
+
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/login'], {
+    queryParams: state.url ? { redirectTo: state.url } : undefined,
+  });
+};

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,204 @@
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { Router } from '@angular/router';
+import { isPlatformBrowser } from '@angular/common';
+import { BehaviorSubject } from 'rxjs';
+import { User } from '@supabase/supabase-js';
+
+import { SupabaseService } from '../shared/supabase-service/supabase.service';
+import {
+  AuthUser,
+  CreateUserRequest,
+} from './models/auth-user.model';
+import {
+  isPermissionLevel,
+  PermissionLevel,
+} from './models/permission-level.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  private readonly supabaseService = inject(SupabaseService);
+  private readonly router = inject(Router);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  private readonly isBrowser = isPlatformBrowser(this.platformId);
+  private readonly storageKey = 'cue-rms:session';
+
+  private readonly currentUserSubject = new BehaviorSubject<AuthUser | null>(
+    null,
+  );
+  readonly currentUser$ = this.currentUserSubject.asObservable();
+
+  private readonly sessionInitialization: Promise<void>;
+
+  constructor() {
+    this.sessionInitialization = this.restoreSession();
+  }
+
+  private async restoreSession(): Promise<void> {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    try {
+      const stored = localStorage.getItem(this.storageKey);
+      if (stored) {
+        const parsed: AuthUser = JSON.parse(stored) as AuthUser;
+        this.currentUserSubject.next(parsed);
+        return;
+      }
+
+      const { data, error } = await this.supabaseService.client.auth.getSession();
+      if (error) {
+        console.error('Failed to restore Supabase session', error);
+        return;
+      }
+
+      const supabaseUser = data.session?.user;
+      if (supabaseUser) {
+        await this.loadUserProfile(supabaseUser);
+      }
+    } catch (error) {
+      console.error('Unexpected error restoring session', error);
+      this.clearPersistedSession();
+    }
+  }
+
+  async ensureSessionResolved(): Promise<void> {
+    await this.sessionInitialization;
+  }
+
+  isAuthenticated(): boolean {
+    return this.currentUserSubject.value !== null;
+  }
+
+  get currentUser(): AuthUser | null {
+    return this.currentUserSubject.value;
+  }
+
+  async login(email: string, password: string): Promise<AuthUser> {
+    const { data, error } =
+      await this.supabaseService.client.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const supabaseUser = data.user;
+    if (!supabaseUser) {
+      throw new Error('No user information returned from Supabase.');
+    }
+
+    const user = await this.loadUserProfile(supabaseUser);
+    return user;
+  }
+
+  async logout(): Promise<void> {
+    try {
+      const { error } = await this.supabaseService.client.auth.signOut();
+      if (error) {
+        console.error('Error signing out of Supabase', error);
+      }
+    } finally {
+      this.currentUserSubject.next(null);
+      this.clearPersistedSession();
+      if (this.isBrowser) {
+        await this.router.navigate(['/login']);
+      }
+    }
+  }
+
+  async createUser(payload: CreateUserRequest): Promise<unknown> {
+    if (!this.canManageUsers()) {
+      throw new Error('You do not have permission to create users.');
+    }
+
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'user-management',
+      {
+        body: {
+          action: 'create-user',
+          payload,
+        },
+      },
+    );
+
+    if (error) {
+      throw new Error(error.message ?? 'Failed to create the user.');
+    }
+
+    return data;
+  }
+
+  hasPermission(level: PermissionLevel): boolean {
+    const user = this.currentUserSubject.value;
+    return user ? user.permissionLevel <= level : false;
+  }
+
+  canManageUsers(permissionLevel?: PermissionLevel): boolean {
+    const level =
+      permissionLevel ?? this.currentUserSubject.value?.permissionLevel;
+    if (level === undefined) {
+      return false;
+    }
+
+    // Only users with privilege level of Administrator (3) or higher (numerically lower)
+    // are allowed to manage users.
+    return level <= PermissionLevel.Administrator;
+  }
+
+  private async loadUserProfile(supabaseUser: User): Promise<AuthUser> {
+    const { data, error } = await this.supabaseService.client
+      .from('user_profiles')
+      .select('display_name, permission_level')
+      .eq('id', supabaseUser.id)
+      .single();
+
+    if (error) {
+      console.error('Failed to fetch user profile from Supabase', error);
+    }
+
+    const permissionLevel = this.parsePermissionLevel(
+      data?.permission_level,
+    );
+
+    const user: AuthUser = {
+      id: supabaseUser.id,
+      email: supabaseUser.email ?? '',
+      displayName: data?.display_name ?? supabaseUser.email ?? 'Unknown user',
+      permissionLevel,
+    };
+
+    this.persistUser(user);
+    this.currentUserSubject.next(user);
+    return user;
+  }
+
+  private parsePermissionLevel(value: unknown): PermissionLevel {
+    if (typeof value === 'number' && isPermissionLevel(value)) {
+      return value;
+    }
+
+    return PermissionLevel.Viewer;
+  }
+
+  private persistUser(user: AuthUser): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    localStorage.setItem(this.storageKey, JSON.stringify(user));
+  }
+
+  private clearPersistedSession(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    localStorage.removeItem(this.storageKey);
+  }
+}

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -1,0 +1,47 @@
+<div class="login-shell">
+  <div class="login-card">
+    <h1>Welcome back</h1>
+    <p>Please sign in with your company credentials to continue.</p>
+
+    <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
+      <label>
+        <span>Email</span>
+        <input
+          type="email"
+          formControlName="email"
+          autocomplete="email"
+          required
+        />
+      </label>
+      <div class="validation" *ngIf="form.controls.email.invalid && form.controls.email.touched">
+        A valid email address is required.
+      </div>
+
+      <label>
+        <span>Password</span>
+        <input
+          type="password"
+          formControlName="password"
+          autocomplete="current-password"
+          required
+        />
+      </label>
+      <div
+        class="validation"
+        *ngIf="form.controls.password.invalid && form.controls.password.touched"
+      >
+        Password must be at least 8 characters long.
+      </div>
+
+      <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
+
+      <button type="submit" [disabled]="isSubmitting">
+        {{ isSubmitting ? 'Signing in…' : 'Sign in' }}
+      </button>
+    </form>
+
+    <p class="support-note">
+      Having trouble signing in? Contact your administrator.
+    </p>
+  </div>
+</div>

--- a/src/app/auth/login/login.component.scss
+++ b/src/app/auth/login/login.component.scss
@@ -1,0 +1,105 @@
+.login-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #0d1b2a, #000);
+  padding: 2rem;
+  color: #0f172a;
+}
+
+.login-card {
+  width: min(420px, 100%);
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 2.5rem 2rem;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: 1.875rem;
+  color: #0f172a;
+}
+
+.login-card p {
+  margin: 0;
+  color: #475569;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  color: #0f172a;
+  gap: 0.4rem;
+}
+
+input {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+}
+
+button[type='submit'] {
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: white;
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button[type='submit']:not([disabled]):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px -8px rgba(79, 70, 229, 0.45);
+}
+
+.validation {
+  color: #dc2626;
+  font-size: 0.875rem;
+  margin-top: -0.4rem;
+}
+
+.error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.support-note {
+  font-size: 0.875rem;
+  color: #64748b;
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    padding: 2rem 1.5rem;
+  }
+}

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -1,0 +1,65 @@
+import { Component, inject, OnInit } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+
+import { AuthService } from '../auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.scss',
+})
+export class LoginComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly fb = inject(FormBuilder);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly form = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(8)]],
+  });
+
+  protected isSubmitting = false;
+  protected errorMessage = '';
+
+  async ngOnInit(): Promise<void> {
+    await this.authService.ensureSessionResolved();
+    if (this.authService.isAuthenticated()) {
+      await this.redirectAfterLogin();
+    }
+  }
+
+  async submit(): Promise<void> {
+    if (this.form.invalid || this.isSubmitting) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.errorMessage = '';
+
+    try {
+      const { email, password } = this.form.getRawValue();
+      await this.authService.login(email, password);
+      await this.redirectAfterLogin();
+    } catch (error) {
+      this.errorMessage =
+        error instanceof Error ? error.message : 'Unable to sign in.';
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+
+  private async redirectAfterLogin(): Promise<void> {
+    const redirectTo = this.route.snapshot.queryParamMap.get('redirectTo') ?? '/';
+    await this.router.navigateByUrl(redirectTo || '/');
+  }
+}

--- a/src/app/auth/models/auth-user.model.ts
+++ b/src/app/auth/models/auth-user.model.ts
@@ -1,0 +1,15 @@
+import { PermissionLevel } from './permission-level.model';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  displayName: string;
+  permissionLevel: PermissionLevel;
+}
+
+export interface CreateUserRequest {
+  email: string;
+  password: string;
+  displayName: string;
+  permissionLevel: PermissionLevel;
+}

--- a/src/app/auth/models/permission-level.model.ts
+++ b/src/app/auth/models/permission-level.model.ts
@@ -1,0 +1,19 @@
+export enum PermissionLevel {
+  SuperAdmin = 1,
+  Administrator = 3,
+  Manager = 5,
+  Staff = 7,
+  Viewer = 9,
+}
+
+export const PERMISSION_LEVELS: PermissionLevel[] = [
+  PermissionLevel.SuperAdmin,
+  PermissionLevel.Administrator,
+  PermissionLevel.Manager,
+  PermissionLevel.Staff,
+  PermissionLevel.Viewer,
+];
+
+export function isPermissionLevel(value: number): value is PermissionLevel {
+  return PERMISSION_LEVELS.includes(value as PermissionLevel);
+}

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.html
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.html
@@ -1,0 +1,132 @@
+<ui-shell>
+  <content>
+    <div class="settings" *ngIf="user$ | async as user; else noUser">
+      <header class="settings__header">
+        <div>
+          <h1>Settings dashboard</h1>
+          <p>Manage your profile, preferences, and team access.</p>
+        </div>
+        <div class="settings__badge">
+          <span class="settings__name">{{ user.displayName }}</span>
+          <span class="settings__permission">
+            {{ permissionLabels[user.permissionLevel] }}
+          </span>
+        </div>
+      </header>
+
+      <nav class="settings__nav">
+        <button
+          type="button"
+          [class.active]="activeSection === 'profile'"
+          (click)="switchSection('profile')"
+        >
+          My profile
+        </button>
+        <button
+          type="button"
+          [class.active]="activeSection === 'add-user'"
+          [disabled]="!canManageUsers(user.permissionLevel)"
+          (click)="switchSection('add-user')"
+        >
+          Add user
+        </button>
+      </nav>
+
+      <section class="settings__panel" *ngIf="activeSection === 'profile'">
+        <h2>Account overview</h2>
+        <dl>
+          <div>
+            <dt>Name</dt>
+            <dd>{{ user.displayName }}</dd>
+          </div>
+          <div>
+            <dt>Email</dt>
+            <dd>{{ user.email }}</dd>
+          </div>
+          <div>
+            <dt>Permission level</dt>
+            <dd>{{ permissionLabels[user.permissionLevel] }}</dd>
+          </div>
+        </dl>
+        <p class="settings__hint">
+          Contact a system administrator if you need your access level adjusted.
+        </p>
+      </section>
+
+      <section class="settings__panel" *ngIf="activeSection === 'add-user'">
+        <h2>Add a new teammate</h2>
+        <p class="settings__hint">
+          Grant access to new staff members directly from this dashboard.
+        </p>
+
+        <ng-container *ngIf="canManageUsers(user.permissionLevel); else permissionWarning">
+          <form
+            class="settings__form"
+            [formGroup]="createUserForm"
+            (ngSubmit)="createUser(user.permissionLevel)"
+            novalidate
+          >
+            <label>
+              <span>Display name</span>
+              <input type="text" formControlName="displayName" required />
+            </label>
+            <div
+              class="validation"
+              *ngIf="createUserForm.controls.displayName.invalid && createUserForm.controls.displayName.touched"
+            >
+              A display name is required.
+            </div>
+
+            <label>
+              <span>Email</span>
+              <input type="email" formControlName="email" required />
+            </label>
+            <div
+              class="validation"
+              *ngIf="createUserForm.controls.email.invalid && createUserForm.controls.email.touched"
+            >
+              Enter a valid email address.
+            </div>
+
+            <label>
+              <span>Temporary password</span>
+              <input type="password" formControlName="password" required />
+            </label>
+            <div
+              class="validation"
+              *ngIf="createUserForm.controls.password.invalid && createUserForm.controls.password.touched"
+            >
+              Password must be at least 8 characters.
+            </div>
+
+            <label>
+              <span>Permission level</span>
+              <select formControlName="permissionLevel">
+                <option *ngFor="let level of permissionLevels" [ngValue]="level">
+                  {{ permissionLabels[level] }}
+                </option>
+              </select>
+            </label>
+
+            <button type="submit" [disabled]="createUserForm.invalid || isSavingUser">
+              {{ isSavingUser ? 'Creating user…' : 'Create user' }}
+            </button>
+
+            <p class="settings__status" *ngIf="saveMessage">{{ saveMessage }}</p>
+          </form>
+        </ng-container>
+        <ng-template #permissionWarning>
+          <p class="settings__warning">
+            You need administrator access (level 3 or higher) to add new users.
+          </p>
+        </ng-template>
+      </section>
+    </div>
+  </content>
+</ui-shell>
+
+<ng-template #noUser>
+  <div class="settings settings--empty">
+    <p>We were unable to load your profile information.</p>
+  </div>
+</ng-template>

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.scss
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.scss
@@ -1,0 +1,194 @@
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem 3rem;
+  color: #0f172a;
+}
+
+.settings--empty {
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.settings__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.settings__header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.settings__header p {
+  margin: 0.25rem 0 0;
+  color: #475569;
+}
+
+.settings__badge {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(129, 140, 248, 0.25));
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.settings__name {
+  font-weight: 700;
+}
+
+.settings__permission {
+  font-size: 0.875rem;
+  color: #1e3a8a;
+}
+
+.settings__nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.settings__nav button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: #e2e8f0;
+  color: #0f172a;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.settings__nav button.active {
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.settings__nav button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings__panel {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.45);
+}
+
+.settings__panel h2 {
+  margin-top: 0;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 2rem;
+  margin: 1.5rem 0;
+}
+
+dl div {
+  background: #f1f5f9;
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+dl dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+}
+
+dl dd {
+  margin: 0.5rem 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.settings__hint {
+  color: #64748b;
+  margin: 0;
+}
+
+.settings__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.settings__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.settings__form input,
+.settings__form select {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+}
+
+.settings__form button {
+  justify-self: flex-start;
+  border: none;
+  border-radius: 999px;
+  padding: 0.8rem 1.6rem;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings__form button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px -8px rgba(14, 165, 233, 0.45);
+}
+
+.settings__form button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings__status {
+  margin: 0;
+  font-weight: 600;
+  color: #16a34a;
+}
+
+.settings__warning {
+  background: rgba(251, 191, 36, 0.15);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(217, 119, 6, 0.35);
+  color: #b45309;
+  font-weight: 600;
+}
+
+.validation {
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 768px) {
+  .settings {
+    padding: 1.5rem;
+  }
+
+  .settings__header {
+    flex-direction: column;
+  }
+}

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.ts
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.ts
@@ -1,0 +1,94 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+import { AuthService } from '../../auth/auth.service';
+import {
+  PERMISSION_LEVELS,
+  PermissionLevel,
+} from '../../auth/models/permission-level.model';
+
+@Component({
+  selector: 'app-settings-dashboard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    UiShellComponent,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './settings-dashboard.component.html',
+  styleUrl: './settings-dashboard.component.scss',
+})
+export class SettingsDashboardComponent {
+  private readonly authService = inject(AuthService);
+  private readonly fb = inject(FormBuilder);
+
+  protected readonly user$ = this.authService.currentUser$;
+  protected readonly permissionLevels = PERMISSION_LEVELS;
+  protected readonly permissionLabels: Record<PermissionLevel, string> = {
+    [PermissionLevel.SuperAdmin]: 'Super administrator (Level 1)',
+    [PermissionLevel.Administrator]: 'Administrator (Level 3)',
+    [PermissionLevel.Manager]: 'Manager (Level 5)',
+    [PermissionLevel.Staff]: 'Staff (Level 7)',
+    [PermissionLevel.Viewer]: 'Viewer (Level 9)',
+  };
+  protected activeSection: 'profile' | 'add-user' = 'profile';
+
+  protected readonly createUserForm = this.fb.nonNullable.group({
+    displayName: ['', [Validators.required, Validators.minLength(2)]],
+    email: ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(8)]],
+    permissionLevel: [PermissionLevel.Staff, [Validators.required]],
+  });
+
+  protected isSavingUser = false;
+  protected saveMessage = '';
+
+  protected switchSection(section: 'profile' | 'add-user'): void {
+    this.activeSection = section;
+    this.saveMessage = '';
+  }
+
+  protected canManageUsers(permissionLevel: PermissionLevel): boolean {
+    return this.authService.canManageUsers(permissionLevel);
+  }
+
+  protected async createUser(permissionLevel: PermissionLevel): Promise<void> {
+    if (!this.canManageUsers(permissionLevel) || this.createUserForm.invalid) {
+      this.createUserForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSavingUser = true;
+    this.saveMessage = '';
+
+    try {
+      const formValue = this.createUserForm.getRawValue();
+      await this.authService.createUser({
+        displayName: formValue.displayName,
+        email: formValue.email,
+        password: formValue.password,
+        permissionLevel: formValue.permissionLevel,
+      });
+      this.saveMessage = 'User invitation sent successfully.';
+      this.createUserForm.reset({
+        displayName: '',
+        email: '',
+        password: '',
+        permissionLevel: PermissionLevel.Staff,
+      });
+    } catch (error) {
+      this.saveMessage =
+        error instanceof Error
+          ? error.message
+          : 'Unable to create the new user.';
+    } finally {
+      this.isSavingUser = false;
+    }
+  }
+}

--- a/src/app/shared/main-navigation-component/main-navigation-component.html
+++ b/src/app/shared/main-navigation-component/main-navigation-component.html
@@ -1,15 +1,37 @@
 <nav>
-  <h1><a routerLink="/">Company Name</a></h1>
+  <div class="nav__brand">
+    <h1><a routerLink="/">Company Name</a></h1>
+  </div>
 
-  <ul>
-    <li><a routerLink="/sales">Sales</a></li>
-    <li><a routerLink="/crew">Crew</a></li>
-    <li><a routerLink="/crew-schedule">Scheduler</a></li>
-    <li><a routerLink="/inventory">Inventory</a></li>
-    <li><a routerLink="/vehicles">Vehicles</a></li>
-    <li><a routerLink="/clashes">Clashes</a></li>
-    <li><a routerLink="/calendar">Calendar</a></li>
-    <li><a routerLink="/reporting">Reporting</a></li>
-    <li><a routerLink="/kb">KBase</a></li>
+  <ul class="nav__links">
+    <li><a routerLink="/sales" routerLinkActive="active">Sales</a></li>
+    <li><a routerLink="/crew" routerLinkActive="active">Crew</a></li>
+    <li>
+      <a routerLink="/crew-schedule" routerLinkActive="active">Scheduler</a>
+    </li>
+    <li>
+      <a routerLink="/inventory" routerLinkActive="active">Inventory</a>
+    </li>
+    <li>
+      <a routerLink="/vehicles" routerLinkActive="active">Vehicles</a>
+    </li>
+    <li><a routerLink="/clashes" routerLinkActive="active">Clashes</a></li>
+    <li><a routerLink="/calendar" routerLinkActive="active">Calendar</a></li>
+    <li>
+      <a routerLink="/reporting" routerLinkActive="active">Reporting</a>
+    </li>
+    <li><a routerLink="/kb" routerLinkActive="active">KBase</a></li>
+    <li><a routerLink="/settings" routerLinkActive="active">Settings</a></li>
   </ul>
+
+  <div class="nav__actions" *ngIf="user$ | async as user; else login">
+    <span class="nav__user">
+      {{ user.displayName }} · L{{ user.permissionLevel }}
+    </span>
+    <button type="button" (click)="logout()">Sign out</button>
+  </div>
+
+  <ng-template #login>
+    <a class="nav__login" routerLink="/login">Sign in</a>
+  </ng-template>
 </nav>

--- a/src/app/shared/main-navigation-component/main-navigation-component.scss
+++ b/src/app/shared/main-navigation-component/main-navigation-component.scss
@@ -2,34 +2,87 @@
 
 nav {
   background-color: $primary-color;
+  color: $off-white;
   height: 100%;
   display: flex;
-  flex-wrap: wrap;
   flex-direction: column;
-  padding-top: 1rem;
+  gap: 1.5rem;
+  padding: 1.5rem 1.75rem;
 }
 
-h1 a {
+.nav__brand h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.nav__brand a {
   color: $off-white;
   text-decoration: none;
-  padding: 20px;
 }
 
-nav li {
+.nav__links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nav__links li {
   width: 100%;
 }
 
-nav li a {
-  padding: 20px;
+.nav__links a {
+  padding: 0.9rem 1rem;
   color: $off-white;
   text-decoration: none;
-  list-style-type: none;
-  display: inline-block;
-  width: 100%;
-  height: 100%;
-  transition: background-color 0.4s ease-in-out 0s;
+  display: block;
+  border-radius: 0.75rem;
+  transition: background-color 0.2s ease;
 }
 
-nav li a:hover {
-  background-color: $secondary-color;
+.nav__links a.active,
+.nav__links a:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.nav__actions {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.nav__user {
+  font-weight: 600;
+}
+
+.nav__actions button {
+  background: rgba(255, 255, 255, 0.14);
+  color: $off-white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.2s ease;
+}
+
+.nav__actions button:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.nav__login {
+  color: $off-white;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.14);
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  align-self: flex-start;
 }

--- a/src/app/shared/main-navigation-component/main-navigation-component.ts
+++ b/src/app/shared/main-navigation-component/main-navigation-component.ts
@@ -1,10 +1,21 @@
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, inject } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { AsyncPipe, NgIf } from '@angular/common';
+
+import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'main-navigation-component',
-  imports: [RouterLink],
+  imports: [RouterLink, RouterLinkActive, NgIf, AsyncPipe],
   templateUrl: './main-navigation-component.html',
   styleUrl: './main-navigation-component.scss',
 })
-export class MainNavigationComponent {}
+export class MainNavigationComponent {
+  private readonly authService = inject(AuthService);
+
+  protected readonly user$ = this.authService.currentUser$;
+
+  protected async logout(): Promise<void> {
+    await this.authService.logout();
+  }
+}


### PR DESCRIPTION
## Summary
- add a Supabase-backed authentication service, login component, and guard to protect application routes
- define numeric permission levels with administrative create-user support via the new settings dashboard
- refresh main navigation with a settings link plus signed-in user context and sign-out handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fddadde0a083238674af2b3fd064c1