### PR TITLE
Load navigation links from Supabase edge function

### DIFF
--- a/src/app/shared/main-navigation-component/main-navigation-component.html
+++ b/src/app/shared/main-navigation-component/main-navigation-component.html
@@ -4,24 +4,9 @@
   </div>
 
   <ul class="nav__links">
-    <li><a routerLink="/sales" routerLinkActive="active">Sales</a></li>
-    <li><a routerLink="/crew" routerLinkActive="active">Crew</a></li>
-    <li>
-      <a routerLink="/crew-schedule" routerLinkActive="active">Scheduler</a>
+    <li *ngFor="let item of navItems">
+      <a [routerLink]="item.path" routerLinkActive="active">{{ item.label }}</a>
     </li>
-    <li>
-      <a routerLink="/inventory" routerLinkActive="active">Inventory</a>
-    </li>
-    <li>
-      <a routerLink="/vehicles" routerLinkActive="active">Vehicles</a>
-    </li>
-    <li><a routerLink="/clashes" routerLinkActive="active">Clashes</a></li>
-    <li><a routerLink="/calendar" routerLinkActive="active">Calendar</a></li>
-    <li>
-      <a routerLink="/reporting" routerLinkActive="active">Reporting</a>
-    </li>
-    <li><a routerLink="/kb" routerLinkActive="active">KBase</a></li>
-    <li><a routerLink="/settings" routerLinkActive="active">Settings</a></li>
   </ul>
 
   <div class="nav__actions" *ngIf="user$ | async as user; else login">

--- a/src/app/shared/main-navigation-component/main-navigation-component.ts
+++ b/src/app/shared/main-navigation-component/main-navigation-component.ts
@@ -1,21 +1,58 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 
 import { AuthService } from '../../auth/auth.service';
+import { dbFunctionsService } from '../supabase-service/db_functions.service';
+
+type NavigationItem = {
+  label: string;
+  path: string;
+  available?: boolean;
+};
 
 @Component({
   selector: 'main-navigation-component',
-  imports: [RouterLink, RouterLinkActive, NgIf, AsyncPipe],
+  imports: [RouterLink, RouterLinkActive, NgIf, NgFor, AsyncPipe],
   templateUrl: './main-navigation-component.html',
   styleUrl: './main-navigation-component.scss',
 })
-export class MainNavigationComponent {
+export class MainNavigationComponent implements OnInit {
   private readonly authService = inject(AuthService);
+  private readonly dbFunctions = inject(dbFunctionsService);
+
+  private readonly organisationId = 'org.xxx';
 
   protected readonly user$ = this.authService.currentUser$;
+  protected navItems: NavigationItem[] = [];
 
   protected async logout(): Promise<void> {
     await this.authService.logout();
+  }
+
+  async ngOnInit(): Promise<void> {
+    await this.loadNavigationItems();
+  }
+
+  private async loadNavigationItems(): Promise<void> {
+    try {
+      const response = await this.dbFunctions.getNavigationItems(
+        this.organisationId,
+      );
+
+      const items = Array.isArray(response) ? response : [];
+
+      this.navItems = items
+        .filter((item) => item && item.available !== false)
+        .map((item) => ({
+          label: item.label ?? item.name ?? '',
+          path: item.path ?? item.route ?? '/',
+          available: item.available,
+        }))
+        .filter((item) => item.label && item.path);
+    } catch (error) {
+      console.error('Failed to load navigation items', error);
+      this.navItems = [];
+    }
   }
 }

--- a/src/app/shared/supabase-service/db_functions.service.ts
+++ b/src/app/shared/supabase-service/db_functions.service.ts
@@ -86,6 +86,24 @@ export class dbFunctionsService {
     }
   }
 
+  async getNavigationItems(orgId: string) {
+    try {
+      const { data, error } =
+        await this.supabaseService.client.functions.invoke('database-access', {
+          headers: {
+            'x-query-type': 'navigation-items',
+            'x-org-id': orgId,
+          },
+        });
+
+      if (error) throw error;
+      return data.data;
+    } catch (err) {
+      console.error('Error fetching navigation items:', err);
+      throw err;
+    }
+  }
+
   getItems() {
     return [
       { id: 1, name: 'test 1', category: 'light', stock: 5, price: 50 },


### PR DESCRIPTION
## Summary
- add a database functions service helper to fetch navigation items for a specific organisation
- update the main navigation component to request Supabase navigation data and render only available links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fe16cd3294832397d0dd85d767a061