### PR TITLE
Add maintenance notes modal for vehicle records

### DIFF
--- a/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.html
+++ b/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.html
@@ -405,7 +405,15 @@
                         <td>{{ record.performedAt }}</td>
                         <td>{{ record.outcome }}</td>
                         <td>{{ record.cost }}</td>
-                        <td>{{ record.notes }}</td>
+                        <td class="maintenance__notes-cell">
+                          <button
+                            type="button"
+                            class="maintenance__notes-button"
+                            (click)="openMaintenanceNotesModal(record)"
+                          >
+                            View notes
+                          </button>
+                        </td>
                         <td class="actions">
                           <button
                             type="button"
@@ -642,6 +650,83 @@
               <button type="submit" class="primary">Add record</button>
             </div>
           </form>
+        </div>
+      </div>
+
+      <div
+        class="modal-backdrop"
+        *ngIf="showMaintenanceNotesModal()"
+        (click)="closeMaintenanceNotesModal()"
+      >
+        <div
+          class="modal notes-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="maintenanceNotesModalTitle"
+          (click)="$event.stopPropagation()"
+        >
+          <header class="modal__header">
+            <h3 id="maintenanceNotesModalTitle">Maintenance notes</h3>
+            <button
+              type="button"
+              class="modal__close"
+              (click)="closeMaintenanceNotesModal()"
+              aria-label="Close maintenance notes"
+            >
+              ×
+            </button>
+          </header>
+          <div class="notes-modal__body" *ngIf="maintenanceNotesRecord() as notesRecord">
+            <ng-container *ngIf="!isEditingMaintenanceNotes(); else editNotes">
+              <div class="notes-modal__content">
+                {{
+                  notesRecord.notes
+                    ? notesRecord.notes
+                    : 'No notes recorded for this maintenance entry.'
+                }}
+              </div>
+              <div class="modal__actions notes-modal__actions">
+                <button
+                  type="button"
+                  class="ghost"
+                  (click)="closeMaintenanceNotesModal()"
+                >
+                  Close
+                </button>
+                <button
+                  type="button"
+                  *ngIf="canEditMaintenance(notesRecord)"
+                  (click)="startMaintenanceNotesEdit()"
+                >
+                  Edit
+                </button>
+              </div>
+            </ng-container>
+            <ng-template #editNotes>
+              <form
+                class="notes-modal__form"
+                (ngSubmit)="saveMaintenanceNotesEdit()"
+              >
+                <label class="notes-modal__label">
+                  <span>Notes</span>
+                  <textarea
+                    rows="8"
+                    [formControl]="maintenanceNotesControl"
+                  ></textarea>
+                </label>
+                <div class="modal__actions notes-modal__actions">
+                  <button type="submit" class="primary">Save</button>
+                  <button
+                    type="button"
+                    class="ghost"
+                    (click)="cancelMaintenanceNotesEdit()"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            </ng-template>
+          </div>
         </div>
       </div>
 

--- a/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.scss
+++ b/src/app/vehicles/vehicle-portal-component/vehicle-portal-component.scss
@@ -548,6 +548,27 @@ table {
   }
 }
 
+.maintenance__notes-cell {
+  white-space: nowrap;
+}
+
+.maintenance__notes-button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(colors.$primary-color, 0.2);
+  background: white;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: background 0.2s ease, color 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(colors.$secondary-color, 0.1);
+    color: colors.$secondary-color;
+  }
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;
@@ -609,6 +630,61 @@ table {
   button {
     align-self: auto;
     margin-left: auto;
+  }
+}
+
+.notes-modal {
+  width: min(520px, 100%);
+}
+
+.notes-modal__body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+}
+
+.notes-modal__content {
+  border: 1px solid rgba(colors.$primary-color, 0.12);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  background: rgba(colors.$off-white, 0.6);
+  color: rgba(colors.$off-black, 0.85);
+  white-space: pre-wrap;
+  min-height: 6rem;
+}
+
+.notes-modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.notes-modal__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  span {
+    font-weight: 600;
+    color: colors.$primary-color;
+  }
+
+  textarea {
+    min-height: 8rem;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid rgba(colors.$primary-color, 0.2);
+    resize: vertical;
+  }
+}
+
+.notes-modal__actions {
+  gap: 0.75rem;
+
+  button {
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the inline maintenance notes cell with a "View notes" button
- add a dedicated modal for reading and editing maintenance notes
- style the new modal and button to match the existing portal visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fedabf0a848323b5ec540f2e390773