### PR TITLE
feat: send branded invites for new users

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -119,10 +119,37 @@ export class AuthService {
       throw new Error('You do not have permission to create users.');
     }
 
+    const admin = this.currentUserSubject.value;
+    const invitation = payload.invitation
+      ? {
+          ...payload.invitation,
+          organisation: {
+            name: payload.invitation.organisation.name,
+            logoUrl: payload.invitation.organisation.logoUrl ?? null,
+          },
+          invitedBy:
+            payload.invitation.invitedBy ??
+            (admin
+              ? {
+                  displayName: admin.displayName,
+                  email: admin.email,
+                }
+              : undefined),
+        }
+      : undefined;
+
+    const requestPayload = {
+      email: payload.email,
+      displayName: payload.displayName,
+      permissionLevel: payload.permissionLevel,
+      invitation,
+      orgSlug: this.org,
+    };
+
     const { data, error } = await this.supabaseService.client.functions.invoke(
       'user-management',
       {
-        body: { action: 'register', payload },
+        body: { action: 'invite', payload: requestPayload },
         headers: { 'x-org-slug': this.org }, // belt + braces
       },
     );

--- a/src/app/auth/models/auth-user.model.ts
+++ b/src/app/auth/models/auth-user.model.ts
@@ -7,9 +7,25 @@ export interface AuthUser {
   permissionLevel: PermissionLevel;
 }
 
+export interface OrganisationBranding {
+  name: string;
+  logoUrl: string | null;
+}
+
+export interface UserInvitationDetails {
+  sendEmail: boolean;
+  message?: string;
+  organisation: OrganisationBranding;
+  resetPasswordRedirect: string;
+  invitedBy?: {
+    displayName: string;
+    email: string;
+  };
+}
+
 export interface CreateUserRequest {
   email: string;
-  password: string;
   displayName: string;
   permissionLevel: PermissionLevel;
+  invitation?: UserInvitationDetails;
 }

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.html
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.html
@@ -97,20 +97,6 @@
             </div>
 
             <label>
-              <span>Temporary password</span>
-              <input type="password" formControlName="password" required />
-            </label>
-            <div
-              class="validation"
-              *ngIf="
-                createUserForm.controls.password.invalid &&
-                createUserForm.controls.password.touched
-              "
-            >
-              Password must be at least 8 characters.
-            </div>
-
-            <label>
               <span>Permission level</span>
               <select formControlName="permissionLevel">
                 <option
@@ -120,6 +106,22 @@
                   {{ permissionLabels[level] }}
                 </option>
               </select>
+            </label>
+
+            <p class="settings__helper">
+              We'll automatically send an invitation email styled with your
+              organisation's logo. The message includes a link for the new
+              teammate to set their password before signing in.
+            </p>
+
+            <label>
+              <span>Personal message (optional)</span>
+              <textarea
+                formControlName="invitationMessage"
+                rows="3"
+                maxlength="500"
+                placeholder="Welcome aboard! I've set you up with Cue RMS access."
+              ></textarea>
             </label>
 
             <button

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.scss
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.scss
@@ -134,11 +134,18 @@ dl dd {
 }
 
 .settings__form input,
-.settings__form select {
+.settings__form select,
+.settings__form textarea {
   border: 1px solid #cbd5f5;
   border-radius: 0.75rem;
   padding: 0.85rem 1rem;
   font-size: 1rem;
+}
+
+.settings__form textarea {
+  min-height: 120px;
+  resize: vertical;
+  font-family: inherit;
 }
 
 .settings__form button {
@@ -167,6 +174,12 @@ dl dd {
   margin: 0;
   font-weight: 600;
   color: #16a34a;
+}
+
+.settings__helper {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
 }
 
 .settings__warning {

--- a/src/app/shared/main-navigation-component/main-navigation-component.ts
+++ b/src/app/shared/main-navigation-component/main-navigation-component.ts
@@ -1,62 +1,16 @@
-import { Component, Injectable, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 
 import { AuthService } from '../../auth/auth.service';
 import { dbFunctionsService } from '../supabase-service/db_functions.service';
-import { environment } from '../../../environments/environment';
-import { SupabaseService } from '../supabase-service/supabase.service';
+import { OrgBrandingService } from '../org-branding/org-branding.service';
 
 type NavigationItem = {
   label: string;
   path: string;
   available?: boolean;
 };
-
-export interface OrgLogoResponse {
-  ok: boolean;
-  organisation?: {
-    id: string;
-    slug: string;
-    name: string;
-    logoUrl: string | null;
-  };
-  error?: string;
-}
-
-@Injectable({ providedIn: 'root' })
-export class NavbarService {
-  private readonly supabaseService = inject(SupabaseService);
-  private readonly baseUrl = environment.supabaseDataUrl.replace(/\/+$/, '');
-  private readonly anonKey = environment.supabaseKey ?? '';
-
-  async getOrgLogo(orgSlug: string): Promise<OrgLogoResponse | null> {
-    try {
-      const { data } = await this.supabaseService.client.auth.getSession();
-      const token = data.session?.access_token ?? this.anonKey;
-
-      const url = `${this.baseUrl}/functions/v1/org-logo?slug=${encodeURIComponent(orgSlug)}`;
-      const res = await fetch(url, {
-        method: 'GET',
-        headers: {
-          authorization: `Bearer ${token}`,
-          apikey: this.anonKey,
-        },
-      });
-
-      if (!res.ok) {
-        console.error('Org logo fetch failed:', res.status, res.statusText);
-        return null;
-      }
-
-      const json = (await res.json()) as OrgLogoResponse;
-      return json;
-    } catch (err) {
-      console.error('NavbarService.getOrgLogo() error:', err);
-      return null;
-    }
-  }
-}
 
 @Component({
   selector: 'main-navigation-component',
@@ -67,7 +21,7 @@ export class NavbarService {
 export class MainNavigationComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly dbFunctions = inject(dbFunctionsService);
-  private readonly navbarService = inject(NavbarService); // ⬅️ NEW
+  private readonly orgBrandingService = inject(OrgBrandingService);
 
   // Use your existing slug/id (header x-org-slug aligns with this)
   private readonly organisationId = 'gravity';
@@ -110,10 +64,12 @@ export class MainNavigationComponent implements OnInit {
   // ⬇️ NEW: fetch org name/logo from your edge function
   private async loadOrgBranding(): Promise<void> {
     try {
-      const resp = await this.navbarService.getOrgLogo(this.organisationId);
-      if (resp?.ok && resp.organisation) {
-        this.orgName = resp.organisation.name || 'Company Name';
-        this.orgLogoUrl = resp.organisation.logoUrl ?? null;
+      const branding = await this.orgBrandingService.getBranding(
+        this.organisationId,
+      );
+      if (branding) {
+        this.orgName = branding.name;
+        this.orgLogoUrl = branding.logoUrl;
       } else {
         this.orgName = 'Company Name';
         this.orgLogoUrl = null;

--- a/src/app/shared/org-branding/org-branding.service.ts
+++ b/src/app/shared/org-branding/org-branding.service.ts
@@ -1,0 +1,63 @@
+import { inject, Injectable } from '@angular/core';
+
+import { SupabaseService } from '../supabase-service/supabase.service';
+import { environment } from '../../../environments/environment';
+import { OrganisationBranding } from '../../auth/models/auth-user.model';
+
+interface OrgLogoResponse {
+  ok: boolean;
+  organisation?: {
+    id: string;
+    slug: string;
+    name: string;
+    logoUrl: string | null;
+  };
+  error?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class OrgBrandingService {
+  private readonly supabaseService = inject(SupabaseService);
+  private readonly baseUrl = environment.supabaseDataUrl.replace(/\/+$/, '');
+  private readonly anonKey = environment.supabaseKey ?? '';
+
+  async getBranding(orgSlug: string): Promise<OrganisationBranding | null> {
+    try {
+      const { data } = await this.supabaseService.client.auth.getSession();
+      const token = data.session?.access_token ?? this.anonKey;
+
+      const response = await fetch(
+        `${this.baseUrl}/functions/v1/org-logo?slug=${encodeURIComponent(orgSlug)}`,
+        {
+          method: 'GET',
+          headers: {
+            authorization: `Bearer ${token}`,
+            apikey: this.anonKey,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        console.error(
+          'OrgBrandingService.getBranding failed',
+          response.status,
+          response.statusText,
+        );
+        return null;
+      }
+
+      const json = (await response.json()) as OrgLogoResponse;
+      if (!json?.ok || !json.organisation) {
+        return null;
+      }
+
+      return {
+        name: json.organisation.name || 'Company Name',
+        logoUrl: json.organisation.logoUrl ?? null,
+      };
+    } catch (error) {
+      console.error('OrgBrandingService.getBranding error', error);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove the manual password requirement when inviting users from the settings dashboard and capture an optional welcome message
- send invitation details (including branding and reset redirect) to the user-management function and share org branding lookup via a reusable service
- update styles and navigation branding consumption to support the new invitation flow

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fee9b37bcc8323a1140911adf77845