### PR TITLE
feat: overhaul knowledge base experience

### DIFF
--- a/src/app/knowledge-base/edge/knowledgebase-attachments.ts
+++ b/src/app/knowledge-base/edge/knowledgebase-attachments.ts
@@ -1,0 +1,72 @@
+// deno-lint-ignore-file no-explicit-any
+import { serve } from 'https://deno.land/std@0.190.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+
+const STORAGE_BUCKET = 'knowledgebase';
+
+serve(async (req) => {
+  try {
+    if (req.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+
+    const formData = await req.formData();
+    const articleId = formData.get('articleId') as string;
+    const file = formData.get('file') as File;
+
+    if (!articleId || !file) {
+      return new Response('Missing payload', { status: 400 });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      {
+        global: { headers: { Authorization: req.headers.get('Authorization') ?? '' } },
+      },
+    );
+    const jwtPayload = JSON.parse(atob((req.headers.get('Authorization') ?? '').split('.')[1] ?? '{}'));
+    const userId = jwtPayload?.sub;
+
+    const filePath = `${articleId}/${crypto.randomUUID()}-${file.name}`;
+    const { error: storageError } = await supabase.storage.from(STORAGE_BUCKET).upload(filePath, file.stream(), {
+      contentType: file.type,
+      upsert: false,
+    });
+    if (storageError) throw storageError;
+
+    const { data, error } = await supabase
+      .from('kb_article_attachments')
+      .insert({
+        article_id: articleId,
+        name: file.name,
+        url: `${Deno.env.get('SUPABASE_URL')}/storage/v1/object/public/${STORAGE_BUCKET}/${filePath}`,
+        type: file.type.startsWith('image/') ? 'image' : 'file',
+        size_bytes: file.size,
+        uploaded_by: userId,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return Response.json({
+      attachment: {
+        id: data.id,
+        articleId: data.article_id,
+        name: data.name,
+        url: data.url,
+        type: data.type,
+        size: data.size_bytes,
+        uploadedAt: data.uploaded_at,
+        uploadedBy: data.uploaded_by,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error: error.message ?? 'Upload failed' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+});

--- a/src/app/knowledge-base/edge/knowledgebase-hub.ts
+++ b/src/app/knowledge-base/edge/knowledgebase-hub.ts
@@ -1,0 +1,535 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// deno-lint-ignore-file no-explicit-any
+import { serve } from 'https://deno.land/std@0.190.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+
+type HandlerContext = {
+  supabase: ReturnType<typeof createClient>;
+  organisationId: string;
+  userId: string;
+};
+
+function createSupabaseClient(req: Request) {
+  const url = Deno.env.get('SUPABASE_URL')!;
+  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+  const client = createClient(url, key, {
+    global: {
+      headers: { Authorization: req.headers.get('Authorization') ?? '' },
+    },
+  });
+  const jwtPayload = JSON.parse(atob((req.headers.get('Authorization') ?? '').split('.')[1] ?? '{}'));
+  return {
+    supabase: client,
+    organisationId: jwtPayload?.organisation_id,
+    userId: jwtPayload?.sub,
+  } as HandlerContext;
+}
+
+async function getArticles(ctx: HandlerContext) {
+  const { data, error } = await ctx.supabase.from('v_kb_articles_with_meta').select('*');
+  if (error) throw error;
+  return data.map((row: any) => mapArticleRow(row));
+}
+
+async function getArticleDetail(ctx: HandlerContext, idOrSlug: string) {
+  const { data, error } = await ctx.supabase
+    .from('kb_articles')
+    .select(
+      `*,
+      tags:kb_article_tags(tag),
+      attachments:kb_article_attachments(*),
+      checklist:kb_article_checklist(*),
+      comments:kb_comments(*, author:profiles(full_name, avatar_url)),
+      quiz:kb_quizzes(*, questions:kb_quiz_questions(*, options:kb_quiz_question_options(*))),
+      related:kb_training_module_articles!left(module:kb_training_modules(title))
+    `,
+    )
+    .or(`id.eq.${idOrSlug},slug.eq.${idOrSlug}`)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return null;
+  return mapArticleDetail(data);
+}
+
+async function searchArticles(ctx: HandlerContext, term: string) {
+  const { data, error } = await ctx.supabase.rpc('search_kb_articles', { search_term: term });
+  if (error) throw error;
+  return data.map((row: any) => mapArticleRow(row));
+}
+
+async function upsertArticle(ctx: HandlerContext, article: any) {
+  const { data, error } = await ctx.supabase
+    .from('kb_articles')
+    .upsert({
+      id: article.id,
+      slug: article.slug,
+      folder_id: article.folderId,
+      title: article.title,
+      excerpt: article.excerpt,
+      body: article.body,
+      hero_image: article.heroImage,
+      estimated_read_mins: article.estimatedReadMins,
+      status: article.status,
+      sequence_index: article.releaseRule?.sequenceIndex,
+      release_requires_articles: article.releaseRule?.requiresArticles ?? [],
+      release_requires_quizzes: article.releaseRule?.requiresQuizzes ?? [],
+      created_by: ctx.userId,
+      updated_by: ctx.userId,
+      organisation_id: ctx.organisationId,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+
+  await ctx.supabase.from('kb_article_tags').delete().eq('article_id', data.id);
+  if (article.tags?.length) {
+    await ctx.supabase
+      .from('kb_article_tags')
+      .insert(article.tags.map((tag: string) => ({ article_id: data.id, tag })));
+  }
+
+  await ctx.supabase.from('kb_article_checklist').delete().eq('article_id', data.id);
+  if (article.checklist?.length) {
+    await ctx.supabase
+      .from('kb_article_checklist')
+      .insert(
+        article.checklist.map((item: any, index: number) => ({
+          id: item.id,
+          article_id: data.id,
+          label: item.label,
+          position: index,
+        })),
+      );
+  }
+
+  return mapArticleRow(data);
+}
+
+async function createComment(ctx: HandlerContext, payload: any) {
+  const { data, error } = await ctx.supabase
+    .from('kb_comments')
+    .insert({
+      article_id: payload.articleId,
+      body: payload.body,
+      mentions: payload.mentions ?? [],
+      parent_id: payload.parentId ?? null,
+      author_id: ctx.userId,
+    })
+    .select(`*, author:profiles(full_name, avatar_url)`)
+    .single();
+  if (error) throw error;
+  return {
+    id: data.id,
+    articleId: data.article_id,
+    body: data.body,
+    createdAt: data.created_at,
+    authorId: ctx.userId,
+    authorName: data.author?.full_name,
+    avatarUrl: data.author?.avatar_url,
+    mentions: data.mentions,
+  };
+}
+
+async function toggleFavourite(ctx: HandlerContext, articleId: string) {
+  const { data } = await ctx.supabase
+    .from('kb_article_favourites')
+    .select('*')
+    .match({ article_id: articleId, user_id: ctx.userId })
+    .maybeSingle();
+  if (data) {
+    await ctx.supabase
+      .from('kb_article_favourites')
+      .delete()
+      .match({ article_id: articleId, user_id: ctx.userId });
+    return { isFavourite: false };
+  }
+  await ctx.supabase
+    .from('kb_article_favourites')
+    .insert({ article_id: articleId, user_id: ctx.userId });
+  return { isFavourite: true };
+}
+
+async function acknowledge(ctx: HandlerContext, articleId: string) {
+  const { data, error } = await ctx.supabase
+    .from('kb_article_acknowledgements')
+    .upsert({ article_id: articleId, user_id: ctx.userId })
+    .select()
+    .single();
+  if (error) throw error;
+  return { acknowledgedAt: data.acknowledged_at };
+}
+
+async function recordProgress(ctx: HandlerContext, articleId: string, completed: boolean) {
+  const payload: any = {
+    article_id: articleId,
+    user_id: ctx.userId,
+    completed,
+    updated_at: new Date().toISOString(),
+  };
+  if (completed) {
+    payload.completed_at = new Date().toISOString();
+  }
+  const { error } = await ctx.supabase.from('kb_user_article_progress').upsert(payload);
+  if (error) throw error;
+}
+
+async function getFolders(ctx: HandlerContext) {
+  const [{ data: folders, error: folderError }, { data: articles }, { data: completions }] = await Promise.all([
+    ctx.supabase.from('kb_folders').select('*').eq('organisation_id', ctx.organisationId),
+    ctx.supabase.from('kb_articles').select('id, folder_id').eq('organisation_id', ctx.organisationId),
+    ctx.supabase
+      .from('kb_user_article_progress')
+      .select('article_id, completed')
+      .eq('user_id', ctx.userId)
+      .eq('completed', true),
+  ]);
+
+  if (folderError) throw folderError;
+  const articleByFolder = new Map<string, string[]>();
+  (articles ?? []).forEach((article: any) => {
+    const list = articleByFolder.get(article.folder_id) ?? [];
+    list.push(article.id);
+    articleByFolder.set(article.folder_id, list);
+  });
+
+  const completedSet = new Set((completions ?? []).map((row: any) => row.article_id));
+
+  return (folders ?? []).map((row: any) => {
+    const articleIds = articleByFolder.get(row.id) ?? [];
+    const completedCount = articleIds.filter((id) => completedSet.has(id)).length;
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      colour: row.colour,
+      icon: row.icon,
+      parentId: row.parent_id,
+      articleCount: articleIds.length,
+      completedCount,
+      unreadCount: Math.max(articleIds.length - completedCount, 0),
+      progressPct: articleIds.length ? Math.round((completedCount / articleIds.length) * 100) : 0,
+    };
+  });
+}
+
+async function getTrainingModules(ctx: HandlerContext) {
+  const { data, error } = await ctx.supabase
+    .from('kb_training_modules')
+    .select('*, articleIds:kb_training_module_articles(article_id), quizIds:kb_training_module_quizzes(quiz_id)')
+    .eq('organisation_id', ctx.organisationId);
+  if (error) throw error;
+  return data.map((row: any) => ({
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    colour: row.colour,
+    folderId: null,
+    dueDate: row.due_date,
+    estimatedMinutes: row.estimated_minutes,
+    articleIds: row.articleIds?.map((a: any) => a.article_id) ?? [],
+    quizIds: row.quizIds?.map((q: any) => q.quiz_id) ?? [],
+  }));
+}
+
+async function getQuiz(ctx: HandlerContext, quizId: string) {
+  const { data, error } = await ctx.supabase
+    .from('kb_quizzes')
+    .select('*, questions:kb_quiz_questions(*, options:kb_quiz_question_options(*))')
+    .eq('id', quizId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return null;
+  return mapQuiz(data);
+}
+
+async function submitQuiz(ctx: HandlerContext, quizId: string, responses: Record<string, unknown>) {
+  const quiz = await getQuiz(ctx, quizId);
+  if (!quiz) throw new Error('Quiz not found');
+  const score = gradeQuiz(quiz, responses);
+  const { data, error } = await ctx.supabase
+    .from('kb_quiz_attempts')
+    .insert({
+      quiz_id: quizId,
+      user_id: ctx.userId,
+      score: score.percentage,
+      passed: score.passed,
+      responses,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return {
+    id: data.id,
+    quizId,
+    userId: ctx.userId,
+    score: data.score,
+    submittedAt: data.submitted_at,
+    passed: data.passed,
+    responses,
+  };
+}
+
+async function trainingProgress(ctx: HandlerContext) {
+  const { data: completed } = await ctx.supabase
+    .from('kb_user_article_progress')
+    .select('article_id')
+    .eq('user_id', ctx.userId)
+    .eq('completed', true);
+  const { data: acknowledged } = await ctx.supabase
+    .from('kb_article_acknowledgements')
+    .select('article_id')
+    .eq('user_id', ctx.userId);
+  const { data: attempts } = await ctx.supabase
+    .from('kb_quiz_attempts')
+    .select('*')
+    .eq('user_id', ctx.userId)
+    .order('submitted_at', { ascending: false });
+  return {
+    userId: ctx.userId,
+    completedArticles: completed?.map((row: any) => row.article_id) ?? [],
+    acknowledgedArticles: acknowledged?.map((row: any) => row.article_id) ?? [],
+    quizAttempts: attempts ?? [],
+    lastSync: new Date().toISOString(),
+  };
+}
+
+async function adminSnapshot(ctx: HandlerContext) {
+  const [articles, users, modules, quizzes] = await Promise.all([
+    ctx.supabase.from('kb_articles').select('id,status'),
+    ctx.supabase.from('profiles').select('id, full_name'),
+    getTrainingModules(ctx),
+    ctx.supabase.from('kb_quizzes').select('id,title'),
+  ]);
+  const { data: progress } = await ctx.supabase
+    .from('kb_user_article_progress')
+    .select('article_id, user_id, completed');
+  const { data: attempts } = await ctx.supabase
+    .from('kb_quiz_attempts')
+    .select('user_id, score, passed');
+
+  const byUser = new Map<string, any>();
+  progress?.forEach((row: any) => {
+    if (!byUser.has(row.user_id)) {
+      byUser.set(row.user_id, { completedArticles: 0, totalArticles: articles.data?.length ?? 0, completedQuizzes: 0, scores: [] });
+    }
+    if (row.completed) byUser.get(row.user_id).completedArticles += 1;
+  });
+  attempts?.forEach((row: any) => {
+    if (!byUser.has(row.user_id)) {
+      byUser.set(row.user_id, { completedArticles: 0, totalArticles: articles.data?.length ?? 0, completedQuizzes: 0, scores: [] });
+    }
+    const entry = byUser.get(row.user_id);
+    entry.completedQuizzes += row.passed ? 1 : 0;
+    entry.scores.push(Number(row.score));
+  });
+
+  const performers = Array.from(byUser.entries()).map(([userId, value]) => {
+    const profile = users.data?.find((u: any) => u.id === userId);
+    return {
+      userId,
+      fullName: profile?.full_name ?? 'Unknown user',
+      completedArticles: value.completedArticles,
+      totalArticles: value.totalArticles,
+      completedQuizzes: value.completedQuizzes,
+      averageScore: value.scores.length ? value.scores.reduce((a: number, b: number) => a + b, 0) / value.scores.length : null,
+      outstandingArticles: value.totalArticles - value.completedArticles,
+      outstandingQuizzes: Math.max(modules.length - value.completedQuizzes, 0),
+    };
+  });
+
+  const averageCompletion = performers.length
+    ? performers.reduce((sum, user) => sum + user.completedArticles / (user.totalArticles || 1), 0) / performers.length * 100
+    : 0;
+
+  return {
+    totalArticles: articles.data?.length ?? 0,
+    totalDrafts: articles.data?.filter((row: any) => row.status !== 'published').length ?? 0,
+    totalUsers: users.data?.length ?? 0,
+    activeTrainingModules: modules.length,
+    averageCompletion,
+    topPerformers: performers.sort((a, b) => (b.averageScore ?? 0) - (a.averageScore ?? 0)).slice(0, 5),
+    atRiskUsers: performers
+      .filter((user) => user.outstandingArticles > 0)
+      .sort((a, b) => b.outstandingArticles - a.outstandingArticles)
+      .slice(0, 5),
+    modules,
+    quizzes: quizzes.data ?? [],
+  };
+}
+
+async function releaseArticles(ctx: HandlerContext, payload: any) {
+  const { error } = await ctx.supabase.from('kb_article_releases').insert(
+    payload.articleIds.map((articleId: string) => ({
+      article_id: articleId,
+      user_ids: payload.userIds ?? [],
+      team_ids: payload.teamIds ?? [],
+      released_by: ctx.userId,
+    })),
+  );
+  if (error) throw error;
+}
+
+function mapArticleRow(row: any) {
+  return {
+    id: row.id,
+    slug: row.slug,
+    folderId: row.folder_id,
+    title: row.title,
+    excerpt: row.excerpt,
+    body: row.body,
+    heroImage: row.hero_image,
+    estimatedReadMins: row.estimated_read_mins,
+    status: row.status,
+    releaseRule: {
+      sequenceIndex: row.sequence_index,
+      requiresArticles: row.release_requires_articles ?? [],
+      requiresQuizzes: row.release_requires_quizzes ?? [],
+    },
+    tags: row.tags ?? [],
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    authorId: row.created_by,
+    updatedBy: row.updated_by,
+    isFavourite: row.is_favourite ?? false,
+  };
+}
+
+function mapArticleDetail(row: any) {
+  return {
+    ...mapArticleRow(row),
+    attachments: row.attachments?.map((a: any) => ({
+      id: a.id,
+      articleId: a.article_id,
+      name: a.name,
+      type: a.type,
+      url: a.url,
+      size: a.size_bytes,
+      uploadedBy: a.uploaded_by,
+      uploadedAt: a.uploaded_at,
+    })),
+    checklist: row.checklist?.map((item: any) => ({ id: item.id, label: item.label })),
+    comments: row.comments?.map((c: any) => ({
+      id: c.id,
+      articleId: c.article_id,
+      authorId: c.author_id,
+      authorName: c.author?.full_name ?? 'Unknown',
+      avatarUrl: c.author?.avatar_url,
+      body: c.body,
+      mentions: c.mentions ?? [],
+      createdAt: c.created_at,
+    })),
+    relatedArticles: [],
+    quiz: row.quiz ? mapQuiz(row.quiz) : undefined,
+  };
+}
+
+function mapQuiz(row: any) {
+  return {
+    id: row.id,
+    articleId: row.article_id,
+    title: row.title,
+    summary: row.summary,
+    passingScore: row.passing_score,
+    questions: row.questions?.map((q: any) => ({
+      id: q.id,
+      prompt: q.prompt,
+      type: q.type,
+      maxSelections: q.max_selections,
+      choices: q.options?.map((option: any) => ({
+        id: option.id,
+        label: option.label,
+        correct: option.correct,
+        explanation: option.explanation,
+      })),
+    })),
+  };
+}
+
+function gradeQuiz(quiz: any, responses: Record<string, unknown>) {
+  let total = 0;
+  let achieved = 0;
+  quiz.questions.forEach((question: any) => {
+    total += 1;
+    const response = responses[question.id];
+    if (question.type === 'short_text') {
+      achieved += response ? 1 : 0;
+      return;
+    }
+    if (question.type === 'true_false') {
+      const correct = question.choices?.[0]?.correct ? true : false;
+      achieved += String(response) === String(correct) ? 1 : 0;
+      return;
+    }
+    const correctIds = (question.choices ?? []).filter((c: any) => c.correct).map((c: any) => c.id);
+    if (!correctIds.length) return;
+    const answerIds = Array.isArray(response) ? response : [response];
+    const isCorrect =
+      correctIds.length === answerIds.length &&
+      correctIds.every((id: string) => answerIds.includes(id));
+    achieved += isCorrect ? 1 : 0;
+  });
+  const percentage = total ? (achieved / total) * 100 : 0;
+  return { percentage, passed: percentage >= quiz.passingScore };
+}
+
+serve(async (req) => {
+  try {
+    const ctx = createSupabaseClient(req);
+    const type = req.headers.get('x-query-type');
+
+    switch (type) {
+      case 'articles-with-meta':
+        return Response.json({ articles: await getArticles(ctx) });
+      case 'article-detail':
+        return Response.json({ article: await getArticleDetail(ctx, req.headers.get('x-article-id') ?? '') });
+      case 'search-articles': {
+        const body = await req.json();
+        return Response.json({ articles: await searchArticles(ctx, body.term ?? '') });
+      }
+      case 'upsert-article': {
+        const body = await req.json();
+        return Response.json({ article: await upsertArticle(ctx, body.article) });
+      }
+      case 'create-comment': {
+        const body = await req.json();
+        return Response.json({ comment: await createComment(ctx, body) });
+      }
+      case 'toggle-favourite':
+        return Response.json(await toggleFavourite(ctx, req.headers.get('x-article-id') ?? ''));
+      case 'acknowledge-article':
+        return Response.json(await acknowledge(ctx, req.headers.get('x-article-id') ?? ''));
+      case 'record-progress': {
+        const body = await req.json();
+        await recordProgress(ctx, body.articleId, body.completed);
+        return Response.json({ success: true });
+      }
+      case 'folders':
+        return Response.json({ folders: await getFolders(ctx) });
+      case 'training-modules':
+        return Response.json({ modules: await getTrainingModules(ctx) });
+      case 'quiz-detail':
+        return Response.json({ quiz: await getQuiz(ctx, req.headers.get('x-quiz-id') ?? '') });
+      case 'submit-quiz': {
+        const body = await req.json();
+        return Response.json({ attempt: await submitQuiz(ctx, req.headers.get('x-quiz-id') ?? '', body.responses ?? {}) });
+      }
+      case 'training-progress':
+        return Response.json({ progress: await trainingProgress(ctx) });
+      case 'admin-snapshot':
+        return Response.json({ snapshot: await adminSnapshot(ctx) });
+      case 'release-articles': {
+        const body = await req.json();
+        await releaseArticles(ctx, body);
+        return Response.json({ success: true });
+      }
+      default:
+        return new Response('Unsupported knowledgebase query type', { status: 400 });
+    }
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error: error.message ?? 'Unknown error' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+});

--- a/src/app/knowledge-base/edge/knowledgebase-schema.sql
+++ b/src/app/knowledge-base/edge/knowledgebase-schema.sql
@@ -1,0 +1,251 @@
+-- Knowledgebase core tables
+create table if not exists public.kb_folders (
+  id uuid primary key default uuid_generate_v4(),
+  organisation_id uuid not null references public.organisations(id) on delete cascade,
+  name text not null,
+  description text,
+  colour text,
+  icon text,
+  parent_id uuid references public.kb_folders(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_articles (
+  id uuid primary key default uuid_generate_v4(),
+  organisation_id uuid not null references public.organisations(id) on delete cascade,
+  folder_id uuid not null references public.kb_folders(id) on delete cascade,
+  slug text unique not null,
+  title text not null,
+  excerpt text,
+  body text not null,
+  hero_image text,
+  estimated_read_mins int default 10,
+  status text not null default 'draft' check (status in ('draft','pending_review','scheduled','published','archived')),
+  sequence_index int,
+  release_requires_articles uuid[] default '{}',
+  release_requires_quizzes uuid[] default '{}',
+  created_by uuid not null references auth.users(id),
+  updated_by uuid references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_article_tags (
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  tag text not null,
+  primary key(article_id, tag)
+);
+
+create table if not exists public.kb_article_attachments (
+  id uuid primary key default uuid_generate_v4(),
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  name text not null,
+  url text not null,
+  type text not null check (type in ('file','image','link')),
+  size_bytes bigint,
+  uploaded_by uuid not null references auth.users(id),
+  uploaded_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_article_checklist (
+  id uuid primary key default uuid_generate_v4(),
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  label text not null,
+  position int not null default 0
+);
+
+create table if not exists public.kb_comments (
+  id uuid primary key default uuid_generate_v4(),
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  parent_id uuid references public.kb_comments(id) on delete cascade,
+  author_id uuid not null references auth.users(id),
+  body text not null,
+  mentions text[] default '{}',
+  resolved_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_article_favourites (
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  primary key(article_id, user_id),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_article_acknowledgements (
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  acknowledged_at timestamptz not null default now(),
+  primary key(article_id, user_id)
+);
+
+create table if not exists public.kb_user_article_progress (
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  completed boolean not null default false,
+  completed_at timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key(article_id, user_id)
+);
+
+create table if not exists public.kb_quizzes (
+  id uuid primary key default uuid_generate_v4(),
+  article_id uuid references public.kb_articles(id) on delete cascade,
+  organisation_id uuid not null references public.organisations(id) on delete cascade,
+  title text not null,
+  summary text,
+  passing_score numeric not null default 80
+);
+
+create table if not exists public.kb_quiz_questions (
+  id uuid primary key default uuid_generate_v4(),
+  quiz_id uuid not null references public.kb_quizzes(id) on delete cascade,
+  prompt text not null,
+  type text not null check (type in ('single','multi','true_false','short_text')),
+  max_selections int,
+  position int default 0
+);
+
+create table if not exists public.kb_quiz_question_options (
+  id uuid primary key default uuid_generate_v4(),
+  question_id uuid not null references public.kb_quiz_questions(id) on delete cascade,
+  label text not null,
+  correct boolean default false,
+  explanation text
+);
+
+create table if not exists public.kb_quiz_attempts (
+  id uuid primary key default uuid_generate_v4(),
+  quiz_id uuid not null references public.kb_quizzes(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  score numeric not null,
+  passed boolean not null,
+  responses jsonb not null,
+  submitted_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_training_modules (
+  id uuid primary key default uuid_generate_v4(),
+  organisation_id uuid not null references public.organisations(id) on delete cascade,
+  title text not null,
+  description text,
+  colour text,
+  due_date date,
+  estimated_minutes int default 0,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.kb_training_module_articles (
+  module_id uuid not null references public.kb_training_modules(id) on delete cascade,
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  position int not null default 0,
+  primary key(module_id, article_id)
+);
+
+create table if not exists public.kb_training_module_quizzes (
+  module_id uuid not null references public.kb_training_modules(id) on delete cascade,
+  quiz_id uuid not null references public.kb_quizzes(id) on delete cascade,
+  position int not null default 0,
+  primary key(module_id, quiz_id)
+);
+
+create table if not exists public.kb_article_releases (
+  id uuid primary key default uuid_generate_v4(),
+  article_id uuid not null references public.kb_articles(id) on delete cascade,
+  user_ids uuid[] default '{}',
+  team_ids uuid[] default '{}',
+  released_by uuid not null references auth.users(id),
+  released_at timestamptz not null default now()
+);
+
+create or replace view public.v_kb_articles_with_meta as
+select
+  a.id,
+  a.slug,
+  a.folder_id,
+  a.title,
+  a.excerpt,
+  a.body,
+  a.hero_image,
+  a.estimated_read_mins,
+  a.status,
+  a.sequence_index,
+  a.release_requires_articles,
+  a.release_requires_quizzes,
+  a.created_at,
+  a.updated_at,
+  a.created_by,
+  a.updated_by,
+  a.organisation_id,
+  coalesce(array_agg(distinct t.tag) filter (where t.tag is not null), '{}') as tags,
+  count(distinct fav.user_id) > 0 as is_favourite
+from public.kb_articles a
+left join public.kb_article_tags t on t.article_id = a.id
+left join public.kb_article_favourites fav on fav.article_id = a.id and fav.user_id = auth.uid()
+where a.organisation_id = uuid(auth.jwt() ->> 'organisation_id')
+group by a.id;
+
+alter table public.kb_articles enable row level security;
+alter table public.kb_article_tags enable row level security;
+alter table public.kb_article_attachments enable row level security;
+alter table public.kb_comments enable row level security;
+alter table public.kb_article_favourites enable row level security;
+alter table public.kb_article_acknowledgements enable row level security;
+alter table public.kb_user_article_progress enable row level security;
+alter table public.kb_quizzes enable row level security;
+alter table public.kb_quiz_questions enable row level security;
+alter table public.kb_quiz_question_options enable row level security;
+alter table public.kb_quiz_attempts enable row level security;
+alter table public.kb_training_modules enable row level security;
+alter table public.kb_training_module_articles enable row level security;
+alter table public.kb_training_module_quizzes enable row level security;
+
+create policy "org members read folders" on public.kb_folders for select using (
+  organisation_id = uuid(auth.jwt() ->> 'organisation_id')
+);
+
+create policy "org members manage folders" on public.kb_folders
+for all using (organisation_id = uuid(auth.jwt() ->> 'organisation_id'))
+with check (organisation_id = uuid(auth.jwt() ->> 'organisation_id'));
+
+create policy "org members manage articles" on public.kb_articles
+for all using (organisation_id = uuid(auth.jwt() ->> 'organisation_id'))
+with check (organisation_id = uuid(auth.jwt() ->> 'organisation_id'));
+
+create policy "org members manage attachments" on public.kb_article_attachments
+for all using (true) with check (true);
+
+create policy "org members manage comments" on public.kb_comments
+for all using (true) with check (true);
+
+create policy "org members manage quiz attempts" on public.kb_quiz_attempts
+for select using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+create policy "org members manage favourites" on public.kb_article_favourites
+for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create policy "org members manage acknowledgements" on public.kb_article_acknowledgements
+for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create policy "org members manage progress" on public.kb_user_article_progress
+for all using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create or replace function public.search_kb_articles(search_term text)
+returns setof public.v_kb_articles_with_meta
+language sql
+security definer
+set search_path = public
+as $$
+  select *
+  from public.v_kb_articles_with_meta
+  where organisation_id = uuid(auth.jwt() ->> 'organisation_id')
+    and (
+      coalesce(title, '') ilike '%' || search_term || '%'
+      or coalesce(excerpt, '') ilike '%' || search_term || '%'
+      or array_to_string(tags, ' ') ilike '%' || search_term || '%'
+    )
+  order by updated_at desc
+  limit 40;
+$$;

--- a/src/app/knowledge-base/knowledge-component/kb-admin-dashboard/kb-admin-dashboard.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-admin-dashboard/kb-admin-dashboard.component.html
@@ -1,0 +1,54 @@
+<ng-container *ngIf="snapshot$ | async as snapshot; else loading">
+  <div class="summary">
+    <div class="tile">
+      <strong>{{ snapshot.totalArticles }}</strong>
+      <span>Total articles</span>
+    </div>
+    <div class="tile">
+      <strong>{{ snapshot.totalDrafts }}</strong>
+      <span>Drafts awaiting review</span>
+    </div>
+    <div class="tile">
+      <strong>{{ snapshot.totalUsers }}</strong>
+      <span>Active users</span>
+    </div>
+    <div class="tile">
+      <strong>{{ snapshot.averageCompletion | number: '1.0-0' }}%</strong>
+      <span>Average completion</span>
+    </div>
+  </div>
+
+  <section class="panels">
+    <article class="panel">
+      <header><h2>Top performers</h2></header>
+      <ul>
+        <li *ngFor="let user of snapshot.topPerformers">
+          <span>{{ user.fullName }}</span>
+          <small>{{ user.completedArticles }}/{{ user.totalArticles }} • {{ user.averageScore | number: '1.0-0' }}%</small>
+        </li>
+      </ul>
+    </article>
+    <article class="panel">
+      <header><h2>Needs attention</h2></header>
+      <ul>
+        <li *ngFor="let user of snapshot.atRiskUsers">
+          <span>{{ user.fullName }}</span>
+          <small>{{ user.outstandingArticles }} outstanding • {{ user.outstandingQuizzes }} quizzes</small>
+        </li>
+      </ul>
+    </article>
+  </section>
+
+  <section class="modules">
+    <h2>Modules</h2>
+    <div class="module" *ngFor="let module of snapshot.modules">
+      <strong>{{ module.title }}</strong>
+      <span>{{ module.articleIds.length }} lessons</span>
+      <a [routerLink]="['/kb/training', module.id]">Open</a>
+    </div>
+  </section>
+</ng-container>
+
+<ng-template #loading>
+  <div class="loading">Loading dashboard…</div>
+</ng-template>

--- a/src/app/knowledge-base/knowledge-component/kb-admin-dashboard/kb-admin-dashboard.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-admin-dashboard/kb-admin-dashboard.component.scss
@@ -1,0 +1,89 @@
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+
+  .tile {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1.25rem;
+    box-shadow: 0 16px 32px rgba(38, 45, 110, 0.12);
+    display: grid;
+    gap: 0.25rem;
+
+    strong {
+      font-size: 1.8rem;
+    }
+
+    span {
+      color: #6f768a;
+    }
+  }
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+
+  .panel {
+    background: #fff;
+    border-radius: 20px;
+    padding: 1.5rem;
+    box-shadow: 0 20px 36px rgba(42, 51, 142, 0.12);
+
+    header h2 {
+      margin-top: 0;
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.75rem;
+
+      li {
+        display: flex;
+        justify-content: space-between;
+        font-size: 0.9rem;
+      }
+
+      small {
+        color: #6f768a;
+      }
+    }
+  }
+}
+
+.modules {
+  background: #fff;
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 36px rgba(42, 51, 142, 0.12);
+  display: grid;
+  gap: 0.75rem;
+
+  .module {
+    display: grid;
+    grid-template-columns: 2fr 1fr auto;
+    align-items: center;
+    gap: 1rem;
+
+    a {
+      background: rgba(95, 110, 252, 0.14);
+      padding: 0.5rem 1rem;
+      border-radius: 12px;
+      color: #3847d0;
+      text-decoration: none;
+    }
+  }
+}
+
+.loading {
+  text-align: center;
+  color: #5f6efc;
+  padding: 3rem 0;
+}

--- a/src/app/knowledge-base/knowledge-component/kb-admin-dashboard/kb-admin-dashboard.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-admin-dashboard/kb-admin-dashboard.component.ts
@@ -1,0 +1,16 @@
+import { AsyncPipe, CommonModule, DatePipe, NgFor, NgIf } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { KbService } from '../kb.service';
+
+@Component({
+  selector: 'app-kb-admin-dashboard',
+  standalone: true,
+  templateUrl: './kb-admin-dashboard.component.html',
+  styleUrls: ['./kb-admin-dashboard.component.scss'],
+  imports: [CommonModule, AsyncPipe, RouterModule, DatePipe, NgFor, NgIf],
+})
+export class KbAdminDashboardComponent {
+  private readonly kb = inject(KbService);
+  readonly snapshot$ = this.kb.getAdminSnapshot();
+}

--- a/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.html
@@ -1,19 +1,140 @@
-<div class="kb-shell">
-  <main class="kb-main article">
-    <ng-container *ngIf="article$ | async as article">
-      <div *ngIf="!article" class="not-found">Article not found.</div>
+<ng-container *ngIf="article$ | async as article; else loading">
+  <div class="article-hero" [style.--hero-image]="article.heroImage || ''">
+    <div class="hero-backdrop"></div>
+    <div class="hero-content">
+      <div class="breadcrumbs">{{ article.folderId }} › {{ article.tags?.join(' / ') }}</div>
+      <h1>{{ article.title }}</h1>
+      <p>{{ article.excerpt }}</p>
+      <div class="hero-meta">
+        <span>Updated {{ article.updatedAt | date: 'medium' }}</span>
+        <span>Estimated {{ article.estimatedReadMins || 5 }} min read</span>
+        <button class="cta" (click)="toggleFavourite(article.id)">
+          {{ article.isFavourite ? '★ Favourite' : '☆ Save for later' }}
+        </button>
+        <button class="ghost" (click)="acknowledge(article.id)">Acknowledge</button>
+      </div>
+      <div class="ack" *ngIf="acknowledgementMessage">{{ acknowledgementMessage }}</div>
+    </div>
+  </div>
 
-      <article *ngIf="article">
-        <h1 class="title">{{ article.title }}</h1>
-        <div class="meta">Updated {{ article.updated_at | date: "medium" }}</div>
+  <div class="article-layout">
+    <main>
+      <section class="article-body" [innerHTML]="article.body"></section>
 
-        <!-- For simplicity, article.body is markdown-ish raw text. Replace with markdown renderer if desired -->
-        <div class="body" [innerHTML]="article.body"></div>
-
-        <div class="tags" *ngIf="article.tags?.length">
-          <span class="tag" *ngFor="let t of article.tags">{{ t }}</span>
+      <section class="attachments" *ngIf="article.attachments?.length">
+        <h2>Attachments</h2>
+        <div class="attachment-list">
+          <a
+            class="attachment"
+            *ngFor="let attachment of article.attachments"
+            [href]="attachment.url"
+            target="_blank"
+          >
+            <span class="icon">{{ attachment.type === 'file' ? '📄' : attachment.type === 'image' ? '🖼️' : '🔗' }}</span>
+            <div>
+              <strong>{{ attachment.name }}</strong>
+              <small>{{ attachment.size ? (attachment.size / 1024 | number: '1.0-0') + ' KB' : 'External link' }}</small>
+            </div>
+          </a>
         </div>
-      </article>
-    </ng-container>
-  </main>
-</div>
+      </section>
+
+      <section class="checklist" *ngIf="article.checklist?.length">
+        <h2>Checklist</h2>
+        <label *ngFor="let item of article.checklist">
+          <input type="checkbox" (change)="completeChecklist(article.id, item.id, $event.target.checked)" />
+          {{ item.label }}
+        </label>
+      </section>
+
+      <section class="quiz" *ngIf="quiz$ | async as quiz">
+        <h2>{{ quiz.title }}</h2>
+        <p>{{ quiz.summary }}</p>
+        <form (ngSubmit)="submitQuiz(article.id, quiz.id)" [formGroup]="quizForm">
+          <div class="quiz-question" *ngFor="let question of quiz.questions">
+            <h3>{{ question.prompt }}</h3>
+            <ng-container [ngSwitch]="question.type">
+              <ng-container *ngSwitchCase="'single'">
+                <label *ngFor="let choice of question.choices">
+                  <input type="radio" [value]="choice.id" [formControlName]="question.id" />
+                  {{ choice.label }}
+                </label>
+              </ng-container>
+              <ng-container *ngSwitchCase="'multi'">
+                <label *ngFor="let choice of question.choices">
+                  <input
+                    type="checkbox"
+                    [checked]="(quizForm.get(question.id)?.value || []).includes(choice.id)"
+                    (change)="toggleMulti(question.id, choice.id, $event.target.checked)"
+                  />
+                  {{ choice.label }}
+                </label>
+              </ng-container>
+              <ng-container *ngSwitchCase="'true_false'">
+                <select [formControlName]="question.id">
+                  <option [ngValue]="true">True</option>
+                  <option [ngValue]="false">False</option>
+                </select>
+              </ng-container>
+              <ng-container *ngSwitchCase="'short_text'">
+                <textarea [formControlName]="question.id"></textarea>
+              </ng-container>
+            </ng-container>
+          </div>
+          <button class="cta" type="submit" [disabled]="submittingQuiz">Submit quiz</button>
+        </form>
+      </section>
+
+      <section class="comments">
+        <h2>Discussion</h2>
+        <div class="comment" *ngFor="let comment of article.comments; trackBy: trackByComment">
+          <div class="avatar">{{ comment.authorName[0] }}</div>
+          <div class="comment-body">
+            <header>
+              <strong>{{ comment.authorName }}</strong>
+              <span>{{ comment.createdAt | date: 'short' }}</span>
+            </header>
+            <p>{{ comment.body }}</p>
+            <div class="mentions" *ngIf="comment.mentions?.length">
+              <span *ngFor="let mention of comment.mentions">@{{ mention }}</span>
+            </div>
+          </div>
+        </div>
+
+        <form class="comment-form" [formGroup]="commentForm" (ngSubmit)="submitComment(article)">
+          <textarea
+            placeholder="Share an insight, ask a question, or @mention a teammate"
+            formControlName="body"
+          ></textarea>
+          <button type="submit" class="cta" [disabled]="submittingComment">Post comment</button>
+        </form>
+      </section>
+    </main>
+
+    <aside>
+      <section class="release" *ngIf="article.releaseRule">
+        <h3>Release rules</h3>
+        <ul>
+          <li *ngIf="article.releaseRule.sequenceIndex as order">Part of sequence #{{ order + 1 }}</li>
+          <li *ngIf="article.releaseRule.requiresArticles?.length">
+            Requires {{ article.releaseRule.requiresArticles.length }} article(s) first
+          </li>
+          <li *ngIf="article.releaseRule.requiresQuizzes?.length">
+            Requires {{ article.releaseRule.requiresQuizzes.length }} quiz(es)
+          </li>
+        </ul>
+      </section>
+
+      <section class="related" *ngIf="(relatedArticles$ | async)?.length as total">
+        <h3>Related articles</h3>
+        <a *ngFor="let related of (relatedArticles$ | async)" [routerLink]="['/kb/article', related.slug || related.id]">
+          {{ related.title }}
+        </a>
+      </section>
+    </aside>
+  </div>
+</ng-container>
+
+<ng-template #loading>
+  <div class="loading">Loading article…</div>
+</ng-template>

--- a/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.scss
@@ -1,41 +1,353 @@
-.kb-shell {
-  display: flex;
-  gap: 1rem;
-  padding: 1.25rem;
-}
-.kb-sidebar {
-  flex: 0 0 250px;
-}
-.kb-main.article {
-  flex: 1;
-  max-width: 900px;
-}
-.title {
-  font-size: 1.6rem;
-  margin: 0 0 0.25rem 0;
-}
-.meta {
-  color: rgba(0, 0, 0, 0.45);
-  margin-bottom: 1rem;
-}
-.body {
-  line-height: 1.6;
-}
-.tag {
-  display: inline-block;
-  padding: 0.25rem 0.5rem;
-  margin: 0.25rem;
-  border-radius: 999px;
-  background: rgba(0, 0, 0, 0.06);
-  font-size: 0.85rem;
-}
-.not-found {
-  padding: 2rem;
-  color: rgba(0, 0, 0, 0.5);
+:host {
+  display: block;
 }
 
-@media (max-width: 760px) {
-  .kb-shell {
+.article-hero {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  margin-bottom: 2rem;
+  min-height: 220px;
+  background: radial-gradient(circle at 20% 20%, rgba(95, 110, 252, 0.4), rgba(95, 110, 252, 0.1));
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--hero-image);
+    background-size: cover;
+    background-position: center;
+    opacity: 0.18;
+  }
+
+  .hero-content {
+    position: relative;
+    padding: 2.5rem;
+    color: #fff;
+    display: flex;
     flex-direction: column;
+    gap: 1rem;
+    background: linear-gradient(135deg, rgba(95, 110, 252, 0.95), rgba(133, 144, 255, 0.8));
+
+    .breadcrumbs {
+      font-size: 0.85rem;
+      opacity: 0.8;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 2.25rem;
+    }
+
+    p {
+      margin: 0;
+      max-width: 600px;
+      line-height: 1.5;
+      opacity: 0.9;
+    }
+
+    .hero-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+
+      span {
+        background: rgba(255, 255, 255, 0.15);
+        padding: 0.5rem 0.9rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+      }
+
+      button {
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        border: none;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.15s ease;
+
+        &.cta {
+          background: #fff;
+          color: #3847d0;
+        }
+
+        &.ghost {
+          background: rgba(255, 255, 255, 0.2);
+          color: #fff;
+        }
+
+        &:hover {
+          transform: translateY(-1px);
+        }
+      }
+    }
+
+    .ack {
+      font-size: 0.85rem;
+      background: rgba(40, 211, 154, 0.3);
+      padding: 0.5rem 0.8rem;
+      border-radius: 12px;
+      align-self: flex-start;
+    }
+  }
+}
+
+.article-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2rem;
+
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+
+    .article-body {
+      background: #fff;
+      border-radius: 18px;
+      padding: 2rem;
+      box-shadow: 0 24px 48px rgba(45, 53, 126, 0.08);
+      line-height: 1.6;
+
+      h2 {
+        margin-top: 2rem;
+      }
+
+      img {
+        max-width: 100%;
+        border-radius: 12px;
+        margin: 1.5rem 0;
+      }
+
+      a {
+        color: #3847d0;
+      }
+    }
+
+    section {
+      background: #fff;
+      border-radius: 18px;
+      padding: 1.75rem;
+      box-shadow: 0 18px 36px rgba(38, 45, 110, 0.08);
+
+      h2 {
+        margin-top: 0;
+      }
+    }
+
+    .attachments {
+      .attachment-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .attachment {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: rgba(95, 110, 252, 0.08);
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        color: inherit;
+        text-decoration: none;
+
+        .icon {
+          font-size: 1.5rem;
+        }
+
+        strong {
+          display: block;
+        }
+
+        small {
+          color: #6f768a;
+        }
+      }
+    }
+
+    .checklist {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+
+      label {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: rgba(40, 211, 154, 0.08);
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+
+        input {
+          width: 18px;
+          height: 18px;
+        }
+      }
+    }
+
+    .quiz {
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+
+      .quiz-question {
+        background: rgba(95, 110, 252, 0.08);
+        padding: 1rem 1.25rem;
+        border-radius: 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+
+        h3 {
+          margin: 0;
+        }
+
+        label {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+        }
+
+        textarea,
+        select {
+          width: 100%;
+          border-radius: 12px;
+          border: 1px solid rgba(95, 110, 252, 0.35);
+          padding: 0.6rem 0.75rem;
+          font-family: inherit;
+        }
+      }
+
+      button.cta {
+        align-self: flex-start;
+        background: #3847d0;
+        color: #fff;
+        border: none;
+        padding: 0.75rem 1.5rem;
+        border-radius: 14px;
+        box-shadow: 0 14px 24px rgba(56, 71, 208, 0.28);
+        cursor: pointer;
+      }
+    }
+
+    .comments {
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+
+      .comment {
+        display: flex;
+        gap: 1rem;
+        background: rgba(248, 249, 255, 0.9);
+        padding: 1rem;
+        border-radius: 14px;
+
+        .avatar {
+          width: 42px;
+          height: 42px;
+          border-radius: 50%;
+          background: #5f6efc;
+          color: #fff;
+          display: grid;
+          place-items: center;
+          font-weight: 600;
+        }
+
+        .comment-body {
+          flex: 1;
+
+          header {
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.85rem;
+            margin-bottom: 0.5rem;
+          }
+
+          .mentions {
+            display: flex;
+            gap: 0.5rem;
+
+            span {
+              background: rgba(95, 110, 252, 0.18);
+              padding: 0.25rem 0.6rem;
+              border-radius: 999px;
+              font-size: 0.75rem;
+            }
+          }
+        }
+      }
+
+      .comment-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+
+        textarea {
+          min-height: 120px;
+          border-radius: 14px;
+          border: 1px solid rgba(95, 110, 252, 0.3);
+          padding: 0.75rem;
+          font-family: inherit;
+        }
+
+        button {
+          align-self: flex-end;
+          padding: 0.6rem 1.4rem;
+          border-radius: 999px;
+          border: none;
+          background: #3847d0;
+          color: #fff;
+          font-weight: 600;
+          cursor: pointer;
+        }
+      }
+    }
+  }
+
+  aside {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+
+    section {
+      background: #fff;
+      border-radius: 18px;
+      padding: 1.5rem;
+      box-shadow: 0 18px 36px rgba(38, 45, 110, 0.08);
+
+      h3 {
+        margin-top: 0;
+      }
+
+      ul {
+        padding-left: 1.25rem;
+        margin: 0;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      a {
+        display: block;
+        padding: 0.5rem 0;
+        color: #3847d0;
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+.loading {
+  text-align: center;
+  padding: 4rem 0;
+  color: #5f6efc;
+}
+
+@media (max-width: 1100px) {
+  .article-layout {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-article/kb-article.component.ts
@@ -1,30 +1,125 @@
-import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { AsyncPipe, CommonModule, DatePipe, NgFor, NgIf, NgSwitch, NgSwitchCase } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
+import { map, switchMap } from 'rxjs';
 import { KbService } from '../kb.service';
-import { switchMap } from 'rxjs/operators';
-import { DatePipe } from '@angular/common';
-import { RouterOutlet } from '@angular/router';
-import { Article } from '../models/article.model';
-import { Observable } from 'rxjs';
+import { ArticleComment, ArticleWithRelations } from '../models/article.model';
 
 @Component({
   selector: 'app-kb-article',
+  standalone: true,
   templateUrl: './kb-article.component.html',
   styleUrls: ['./kb-article.component.scss'],
-  imports: [CommonModule, DatePipe, RouterOutlet],
+  imports: [CommonModule, AsyncPipe, DatePipe, ReactiveFormsModule, NgFor, NgIf, NgSwitch, NgSwitchCase],
 })
-export class KbArticleComponent implements OnInit {
-  constructor(
-    private route: ActivatedRoute,
-    private kb: KbService,
-  ) {}
+export class KbArticleComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly kb = inject(KbService);
+  private readonly fb = inject(FormBuilder);
 
-  article$!: Observable<Article | undefined>;
+  readonly article$ = this.route.paramMap.pipe(
+    switchMap((params) => this.kb.get(params.get('id') ?? '')),
+  );
 
-  ngOnInit(): void {
-    this.article$ = this.route.paramMap.pipe(
-      switchMap((params) => this.kb.get(params.get('id') || '')),
-    );
+  readonly relatedArticles$ = this.article$.pipe(map((article) => article?.relatedArticles ?? []));
+  readonly quiz$ = this.article$.pipe(map((article) => article?.quiz));
+
+  readonly commentForm = this.fb.group({
+    body: ['', [Validators.required, Validators.minLength(3)]],
+    mentions: [[] as string[]],
+  });
+
+  quizForm: FormGroup = this.fb.group({});
+
+  submittingComment = false;
+  submittingQuiz = false;
+  acknowledgementMessage = '';
+
+  constructor() {
+    this.quiz$.subscribe((quiz) => {
+      if (!quiz) return;
+      const controls: Record<string, FormControl> = {};
+      quiz.questions.forEach((question) => {
+        const validators = [Validators.required];
+        let initial: unknown = [];
+        switch (question.type) {
+          case 'short_text':
+            initial = '';
+            break;
+          case 'true_false':
+            initial = null;
+            break;
+          case 'single':
+            initial = null;
+            break;
+          default:
+            initial = [];
+            break;
+        }
+        controls[question.id] = new FormControl(initial, validators);
+      });
+      this.quizForm = this.fb.group(controls);
+    });
+  }
+
+  submitComment(article: ArticleWithRelations) {
+    if (this.commentForm.invalid || this.submittingComment) return;
+    this.submittingComment = true;
+    const { body, mentions } = this.commentForm.value;
+
+    this.kb.addComment(article.id, body ?? '', mentions ?? []).subscribe({
+      next: (comment) => {
+        article.comments = [...(article.comments ?? []), comment];
+        this.commentForm.reset({ body: '', mentions: [] });
+        this.submittingComment = false;
+      },
+      error: () => {
+        this.submittingComment = false;
+      },
+    });
+  }
+
+  acknowledge(articleId: string) {
+    this.kb.acknowledgeArticle(articleId).subscribe((res) => {
+      this.acknowledgementMessage = `Acknowledged on ${new Date(res.acknowledgedAt).toLocaleString()}`;
+    });
+  }
+
+  toggleFavourite(articleId: string) {
+    this.kb.toggleFavourite(articleId).subscribe();
+  }
+
+  completeChecklist(articleId: string, itemId: string, completed: boolean) {
+    this.kb.recordArticleProgress(articleId, completed).subscribe();
+  }
+
+  submitQuiz(articleId: string, quizId: string) {
+    if (this.quizForm.invalid || this.submittingQuiz) return;
+    this.submittingQuiz = true;
+    this.kb.submitQuizAttempt(quizId, this.quizForm.value).subscribe({
+      next: () => {
+        this.submittingQuiz = false;
+        this.acknowledgementMessage = 'Quiz submitted! We will let your admin know you passed.';
+      },
+      error: () => {
+        this.submittingQuiz = false;
+      },
+    });
+  }
+
+  trackByComment(_: number, comment: ArticleComment) {
+    return comment.id;
+  }
+
+  toggleMulti(questionId: string, choiceId: string, checked: boolean) {
+    const control = this.quizForm.get(questionId);
+    if (!control) return;
+    const value: string[] = Array.isArray(control.value) ? control.value : [];
+    const next = checked
+      ? Array.from(new Set([...value, choiceId]))
+      : value.filter((id) => id !== choiceId);
+    control.setValue(next);
+    control.markAsDirty();
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.html
@@ -1,23 +1,87 @@
-<div class="kb-shell">
-  <div class="kb-main">
-    <section class="kb-cards">
-      <ng-container *ngIf="articles$ | async as articles">
-        <div *ngIf="articles.length === 0" class="empty">
-          No articles found.
-        </div>
-        <article class="kb-card" *ngFor="let a of articles">
-          <a [routerLink]="['/kb/article', a.id]" class="kb-card-link">
-            <h3 class="kb-card-title">{{ a.title }}</h3>
-            <p class="kb-card-excerpt">{{ a.excerpt }}</p>
-            <div class="kb-card-meta">
-              <small *ngIf="a.tags?.length">{{ a.tags?.join(" • ") }}</small>
-              <small *ngIf="a.updated_at">
-                — {{ a.updated_at | date: "mediumDate" }}</small
-              >
-            </div>
-          </a>
-        </article>
-      </ng-container>
-    </section>
+<div class="kb-dashboard" *ngIf="(stats$ | async) as stats">
+  <div class="hero">
+    <div class="hero-copy">
+      <h1>Knowledge classroom</h1>
+      <p>Pick up right where you left off. Your learning journey continues below.</p>
+      <div class="hero-stats">
+        <div class="pill"><strong>{{ stats.total }}</strong><span>Total articles</span></div>
+        <div class="pill success"><strong>{{ stats.published }}</strong><span>Published</span></div>
+        <div class="pill warning"><strong>{{ stats.drafts }}</strong><span>Drafts</span></div>
+        <div class="pill neutral"><strong>{{ stats.folders }}</strong><span>Folders</span></div>
+      </div>
+    </div>
+    <div class="hero-actions">
+      <button class="cta" routerLink="/kb/submit-article">➕ New article</button>
+      <button class="ghost" (click)="setViewMode('grid')">Grid</button>
+      <button class="ghost" (click)="setViewMode('timeline')">Timeline</button>
+      <button class="ghost" (click)="setViewMode('folders')">Folders</button>
+    </div>
   </div>
 </div>
+
+<ng-container *ngIf="(viewMode$ | async) as mode">
+  <section class="grid-view" *ngIf="mode === 'grid'">
+    <article class="class-card" *ngFor="let article of (articles$ | async); trackBy: trackById">
+      <header>
+        <div class="class-meta">
+          <span class="status" [class.draft]="article.status !== 'published'">{{ article.status }}</span>
+          <span class="folder">{{ article.folderId }}</span>
+        </div>
+        <button
+          class="favourite"
+          title="Toggle favourite"
+          [class.active]="article.isFavourite"
+          (click)="toggleFavourite(article, $event)"
+        >
+          {{ article.isFavourite ? '★' : '☆' }}
+        </button>
+      </header>
+      <h3>{{ article.title }}</h3>
+      <p>{{ article.excerpt }}</p>
+      <footer>
+        <div class="chips">
+          <span class="chip" *ngFor="let tag of article.tags">#{{ tag }}</span>
+        </div>
+        <div class="meta">Updated {{ article.updatedAt | date: 'mediumDate' }}</div>
+        <a class="cta" [routerLink]="['/kb/article', article.slug || article.id]">Open</a>
+      </footer>
+    </article>
+  </section>
+
+  <section class="timeline-view" *ngIf="mode === 'timeline'">
+    <div class="timeline-group" *ngFor="let group of (timeline$ | async)">
+      <h2>{{ group.period }}</h2>
+      <div class="timeline-card" *ngFor="let article of group.articles; trackBy: trackById">
+        <div class="timeline-date">{{ article.createdAt | date: 'MMM d' }}</div>
+        <div class="timeline-body">
+          <h3>{{ article.title }}</h3>
+          <p>{{ article.excerpt }}</p>
+          <div class="timeline-tags">
+            <span *ngFor="let tag of article.tags">#{{ tag }}</span>
+          </div>
+          <a [routerLink]="['/kb/article', article.slug || article.id]" class="cta">Review</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="folder-view" *ngIf="mode === 'folders'">
+    <div class="folder" *ngFor="let folder of (folders$ | async); trackBy: trackByFolder">
+      <header>
+        <div class="icon" [style.background]="folder.colour || '#5f6efc'">{{ folder.icon || '📁' }}</div>
+        <div>
+          <h3>{{ folder.name }}</h3>
+          <p>{{ folder.description }}</p>
+        </div>
+      </header>
+      <footer>
+        <div class="progress">
+          <span>{{ folder.completedCount }}/{{ folder.articleCount }} complete</span>
+          <div class="bar">
+            <div class="fill" [style.width.%]="folder.progressPct || 0"></div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </section>
+</ng-container>

--- a/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.scss
@@ -1,67 +1,352 @@
-:host {
-  display: inline-block;
+.kb-dashboard {
+  margin-bottom: 2rem;
+
+  .hero {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    background: linear-gradient(135deg, #5f6efc, #7f85ff);
+    color: #fff;
+    border-radius: 18px;
+    padding: 2.25rem;
+    box-shadow: 0 18px 40px rgba(52, 63, 189, 0.2);
+    gap: 1.5rem;
+
+    .hero-copy {
+      max-width: 540px;
+
+      h1 {
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+      }
+
+      p {
+        opacity: 0.85;
+        margin-bottom: 1.5rem;
+      }
+    }
+
+    .hero-stats {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+
+      .pill {
+        background: rgba(255, 255, 255, 0.12);
+        padding: 0.75rem 1rem;
+        border-radius: 999px;
+        display: flex;
+        flex-direction: column;
+        min-width: 120px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-size: 0.75rem;
+
+        strong {
+          font-size: 1.4rem;
+          line-height: 1.2;
+        }
+
+        &.success {
+          background: rgba(86, 235, 177, 0.24);
+        }
+
+        &.warning {
+          background: rgba(255, 196, 71, 0.28);
+        }
+
+        &.neutral {
+          background: rgba(255, 255, 255, 0.18);
+        }
+      }
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+
+      button {
+        padding: 0.75rem 1.25rem;
+        border-radius: 14px;
+        border: none;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.12s ease, box-shadow 0.12s ease;
+
+        &.cta {
+          background: #fff;
+          color: #3847d0;
+          box-shadow: 0 12px 24px rgba(16, 22, 97, 0.25);
+        }
+
+        &.ghost {
+          background: rgba(255, 255, 255, 0.16);
+          color: #fff;
+        }
+
+        &:hover {
+          transform: translateY(-2px);
+          box-shadow: 0 16px 32px rgba(16, 22, 97, 0.25);
+        }
+      }
+    }
+  }
 }
 
-.kb-shell {
-  display: flex;
-  gap: 1rem;
-}
-.kb-sidebar {
-  flex: 0 0 250px;
-}
-.kb-main {
-  flex: 1 1 auto;
-}
-
-.kb-cards {
+.grid-view {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  gap: 1.5rem;
+
+  .class-card {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 16px 30px rgba(59, 67, 160, 0.12);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border-top: 6px solid rgba(95, 110, 252, 0.65);
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .class-meta {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+
+        .status {
+          padding: 0.25rem 0.65rem;
+          border-radius: 999px;
+          background: rgba(106, 118, 255, 0.16);
+          &.draft {
+            background: rgba(255, 173, 66, 0.2);
+            color: #c97714;
+          }
+        }
+
+        .folder {
+          background: rgba(36, 44, 136, 0.12);
+          padding: 0.25rem 0.65rem;
+          border-radius: 999px;
+        }
+      }
+
+      .favourite {
+        background: transparent;
+        border: none;
+        font-size: 1.35rem;
+        cursor: pointer;
+        color: rgba(255, 255, 255, 0.6);
+        transition: transform 0.15s ease;
+
+        &.active {
+          color: #ffb347;
+        }
+
+        &:hover {
+          transform: scale(1.1);
+        }
+      }
+    }
+
+    h3 {
+      font-size: 1.15rem;
+      font-weight: 600;
+      margin: 0;
+    }
+
+    p {
+      color: #5f6575;
+      flex-grow: 1;
+    }
+
+    footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+
+      .chips {
+        display: flex;
+        gap: 0.4rem;
+        flex-wrap: wrap;
+
+        .chip {
+          background: rgba(95, 110, 252, 0.12);
+          padding: 0.3rem 0.6rem;
+          border-radius: 999px;
+          font-size: 0.75rem;
+          color: #3847d0;
+        }
+      }
+
+      .meta {
+        font-size: 0.75rem;
+        color: #8a8fa3;
+      }
+
+      .cta {
+        background: #3847d0;
+        color: #fff;
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 600;
+        box-shadow: 0 12px 20px rgba(56, 71, 208, 0.25);
+      }
+    }
+  }
 }
 
-.kb-card {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
-  padding: 1rem;
-  transition:
-    transform 0.12s ease,
-    box-shadow 0.12s ease;
-}
-.kb-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
-}
-.kb-card-link {
-  color: inherit;
-  text-decoration: none;
-  display: block;
-}
-.kb-card-title {
-  margin: 0 0 0.5rem 0;
-  font-size: 1.05rem;
-}
-.kb-card-excerpt {
-  margin: 0 0 0.75rem 0;
-  color: rgba(0, 0, 0, 0.65);
-}
-.kb-card-meta {
-  color: rgba(0, 0, 0, 0.45);
-  font-size: 0.85rem;
+.timeline-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  .timeline-group {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 18px 40px rgba(56, 71, 208, 0.08);
+
+    h2 {
+      margin-top: 0;
+      color: #3847d0;
+    }
+
+    .timeline-card {
+      display: grid;
+      grid-template-columns: 120px 1fr;
+      gap: 1.25rem;
+      padding: 1.25rem 0;
+      border-bottom: 1px dashed rgba(89, 100, 216, 0.2);
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      .timeline-date {
+        font-weight: 600;
+        color: #5f6efc;
+        font-size: 0.95rem;
+      }
+
+      .timeline-body {
+        h3 {
+          margin: 0 0 0.5rem;
+        }
+
+        p {
+          margin: 0 0 0.75rem;
+          color: #5f6575;
+        }
+
+        .timeline-tags {
+          display: flex;
+          gap: 0.5rem;
+          flex-wrap: wrap;
+          margin-bottom: 0.75rem;
+
+          span {
+            background: rgba(95, 110, 252, 0.14);
+            padding: 0.3rem 0.65rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+          }
+        }
+
+        .cta {
+          color: #3847d0;
+          font-weight: 600;
+        }
+      }
+    }
+  }
 }
 
-.empty {
-  color: rgba(0, 0, 0, 0.45);
-  padding: 2rem;
-  text-align: center;
+.folder-view {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+
+  .folder {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 16px 36px rgba(33, 38, 89, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    header {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+
+      .icon {
+        width: 56px;
+        height: 56px;
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        font-size: 1.5rem;
+        color: #fff;
+      }
+
+      h3 {
+        margin: 0;
+      }
+
+      p {
+        margin: 0;
+        color: #6f768a;
+        font-size: 0.9rem;
+      }
+    }
+
+    footer {
+      .progress {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+
+        span {
+          font-size: 0.8rem;
+          color: #80859c;
+        }
+
+        .bar {
+          background: rgba(95, 110, 252, 0.12);
+          height: 8px;
+          border-radius: 999px;
+          overflow: hidden;
+
+          .fill {
+            background: #5f6efc;
+            height: 100%;
+            transition: width 0.3s ease;
+          }
+        }
+      }
+    }
+  }
 }
 
-@media (max-width: 760px) {
-  .kb-shell {
+@media (max-width: 1024px) {
+  .kb-dashboard .hero {
     flex-direction: column;
   }
-  .kb-sidebar {
-    order: 2;
+
+  .timeline-view .timeline-card {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.ts
@@ -1,22 +1,51 @@
-import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common'; // provides AsyncPipe, NgIf, NgFor
+import { AsyncPipe, CommonModule, DatePipe, NgFor, NgIf } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { combineLatest, map } from 'rxjs';
 import { KbService } from '../kb.service';
-import { Observable } from 'rxjs';
 import { Article } from '../models/article.model';
-import { KbSearchComponent } from '../kb-search/kb-search.component';
+import { KnowledgeFolder } from '../models/folder.model';
+import { KnowledgeViewMode } from '../models/view-mode.type';
 
 @Component({
   selector: 'app-kb-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, KbSearchComponent],
+  imports: [CommonModule, RouterModule, AsyncPipe, NgIf, NgFor, DatePipe],
   templateUrl: './kb-list.component.html',
   styleUrls: ['./kb-list.component.scss'],
 })
-export class KbListComponent implements OnInit {
-  articles$!: Observable<Article[]>;
-  constructor(private kb: KbService) {}
-  ngOnInit() {
-    this.articles$ = this.kb.list();
+export class KbListComponent {
+  private readonly kb = inject(KbService);
+
+  readonly articles$ = this.kb.list();
+  readonly viewMode$ = this.kb.viewModeChanges();
+  readonly folders$ = this.kb.listFolders();
+  readonly timeline$ = this.kb.buildTimelineGrouping(this.articles$);
+
+  readonly stats$ = combineLatest([this.articles$, this.folders$]).pipe(
+    map(([articles, folders]) => ({
+      total: articles.length,
+      published: articles.filter((a) => a.status === 'published').length,
+      drafts: articles.filter((a) => a.status !== 'published').length,
+      folders: folders.length,
+    })),
+  );
+
+  protected trackById(_: number, article: Article) {
+    return article.id;
+  }
+
+  protected trackByFolder(_: number, folder: KnowledgeFolder) {
+    return folder.id;
+  }
+
+  setViewMode(mode: KnowledgeViewMode) {
+    this.kb.setViewMode(mode);
+  }
+
+  toggleFavourite(article: Article, event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.kb.toggleFavourite(article.id).subscribe((res) => (article.isFavourite = res.isFavourite));
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-routing.module.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-routing.module.ts
@@ -3,6 +3,8 @@ import { RouterModule, Routes } from '@angular/router';
 import { KbListComponent } from './kb-list/kb-list.component';
 import { KbArticleComponent } from './kb-article/kb-article.component';
 import { KbSubmitArticleComponent } from './kb-submit-article/kb-submit-article.component';
+import { KbTrainingComponent } from './kb-training/kb-training.component';
+import { KbAdminDashboardComponent } from './kb-admin-dashboard/kb-admin-dashboard.component';
 
 const routes: Routes = [
   { path: '', component: KbListComponent },
@@ -11,6 +13,8 @@ const routes: Routes = [
     path: 'submit-article',
     component: KbSubmitArticleComponent,
   },
+  { path: 'training', component: KbTrainingComponent },
+  { path: 'admin', component: KbAdminDashboardComponent },
 ];
 
 @NgModule({

--- a/src/app/knowledge-base/knowledge-component/kb-search/kb-search.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-search/kb-search.component.html
@@ -1,7 +1,13 @@
 <div class="kb-search">
-  <input [formControl]="control" placeholder="Search the knowledge base..." />
-  <button *ngIf="control.value" (click)="clear()">✕</button>
-  <div class="bcount" *ngIf="resultsCount !== null">
-    {{ resultsCount }} results
+  <span class="icon">🔍</span>
+  <input [formControl]="control" placeholder="Search the knowledge classroom" />
+  <button *ngIf="control.value" (click)="clear()" type="button">✕</button>
+</div>
+
+<div class="search-popover" *ngIf="control.value && (results$ | async) as results">
+  <div class="result" *ngFor="let result of results | slice: 0:5">
+    <div class="title">{{ result.title }}</div>
+    <div class="excerpt">{{ result.excerpt }}</div>
   </div>
+  <div class="empty" *ngIf="results.length === 0">No matches yet. Try another keyword.</div>
 </div>

--- a/src/app/knowledge-base/knowledge-component/kb-search/kb-search.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-search/kb-search.component.scss
@@ -1,25 +1,59 @@
-:host {
-  height: 40px;
-}
-
 .kb-search {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.6rem 1rem;
+  box-shadow: 0 12px 24px rgba(48, 56, 145, 0.12);
+
+  .icon {
+    font-size: 1.1rem;
+    opacity: 0.6;
+  }
+
+  input {
+    border: none;
+    outline: none;
+    flex: 1;
+    font-size: 1rem;
+  }
+
+  button {
+    border: none;
+    background: rgba(95, 110, 252, 0.14);
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    cursor: pointer;
+  }
 }
-.kb-search input {
-  flex: 1;
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.09);
-}
-.kb-search button {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-}
-.count {
-  margin-left: 0.5rem;
-  color: rgba(0, 0, 0, 0.45);
-  font-size: 0.9rem;
+
+.search-popover {
+  margin-top: 0.75rem;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 16px 32px rgba(38, 45, 110, 0.12);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+
+  .result {
+    display: grid;
+    gap: 0.25rem;
+
+    .title {
+      font-weight: 600;
+    }
+
+    .excerpt {
+      color: #70768c;
+      font-size: 0.85rem;
+    }
+  }
+
+  .empty {
+    text-align: center;
+    color: #70768c;
+  }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.html
@@ -1,5 +1,19 @@
-<app-kb-sidebar></app-kb-sidebar>
-<app-kb-search></app-kb-search>
-<div class="kb-content">
-  <router-outlet></router-outlet>
+<div class="knowledge-shell">
+  <aside class="sidebar-area">
+    <app-kb-sidebar></app-kb-sidebar>
+  </aside>
+
+  <div class="main-area">
+    <header class="top-bar">
+      <div class="title">
+        <h1>Knowledgebase</h1>
+        <p>Structured like Google Classroom – curated streams, folders and release gates.</p>
+      </div>
+      <app-kb-search></app-kb-search>
+    </header>
+
+    <div class="content">
+      <router-outlet></router-outlet>
+    </div>
+  </div>
 </div>

--- a/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.scss
@@ -1,19 +1,52 @@
-:host {
+.knowledge-shell {
   display: grid;
-  grid-template-columns: 260px 1fr;
-  grid-template-rows: 80px 1fr;
-  min-height: 100vh;
+  grid-template-columns: 320px minmax(0, 1fr);
+  min-height: calc(100vh - 80px);
+  background: #eef1ff;
 }
 
-.kb-content {
-  grid-column: 2;
-  grid-row: 2;
+.sidebar-area {
+  border-right: 1px solid rgba(95, 110, 252, 0.12);
 }
-app-kb-search {
-  grid-column: 2;
-  grid-row: 1;
+
+.main-area {
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  gap: 1.5rem;
 }
-app-kb-sidebar {
-  grid-column: 1;
-  grid-row: 1 / span 2;
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+
+  .title {
+    h1 {
+      margin: 0;
+      font-size: 2rem;
+    }
+
+    p {
+      margin: 0.35rem 0 0;
+      color: #5f6575;
+    }
+  }
+}
+
+.content {
+  flex: 1;
+  overflow: auto;
+  padding-bottom: 4rem;
+}
+
+@media (max-width: 1100px) {
+  .knowledge-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar-area {
+    order: 2;
+  }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.html
@@ -1,25 +1,48 @@
 <aside class="sidebar">
-  <div class="brand">Knowledge Base</div>
+  <div class="brand">
+    <h2>Workspace</h2>
+    <p>Organise learning like Google Classroom, but tailored to your crews.</p>
+    <button routerLink="/kb/training" class="cta">📘 Training hub</button>
+  </div>
 
-  <nav>
-    <div class="section-title">Categories</div>
-    <ul>
-      <li *ngFor="let cat of categories">
-        <a [routerLink]="['/kb', cat.slug]">{{ cat.name }}</a>
-        <ul *ngIf="cat.children">
-          <li *ngFor="let child of cat.children">
-            <a [routerLink]="['/kb/article/', child.id]">{{ child.title }}</a>
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+  <section *ngIf="(favourites$ | async)?.length">
+    <h3>Pinned folders</h3>
+    <button
+      class="folder-pill"
+      *ngFor="let folder of (favourites$ | async)"
+      (click)="selectFolder(folder)"
+    >
+      <span class="dot" [style.background]="folder.colour"></span>
+      {{ folder.name }}
+    </button>
+  </section>
 
-  <section class="help">
-    <h4>Quick links</h4>
-    <ul>
-      <li><a href="www.cue-go.co.nz/contact">Contact support</a></li>
-      <li><a [routerLink]="['/kb/submit-article']">Submit article</a></li>
-    </ul>
+  <section>
+    <h3>All folders</h3>
+    <div class="folder-list" *ngIf="(folders$ | async) as folders">
+      <article class="folder" *ngFor="let folder of folders" (click)="selectFolder(folder)">
+        <div class="icon" [style.background]="folder.colour || '#5f6efc'">{{ folder.icon || '📁' }}</div>
+        <div class="copy">
+          <strong>{{ folder.name }}</strong>
+          <span>{{ folder.completedCount }}/{{ folder.articleCount }} completed</span>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section *ngIf="(modules$ | async) as modules">
+    <h3>Training playlists</h3>
+    <div class="module" *ngFor="let module of modules">
+      <header>
+        <span class="colour" [style.background]="module.colour || '#4ac6b7'"></span>
+        <div>
+          <strong>{{ module.title }}</strong>
+          <small>{{ module.articleIds.length }} lessons • {{ module.quizIds.length }} quizzes</small>
+        </div>
+      </header>
+      <footer>
+        <button class="ghost" [routerLink]="['/kb/training', module.id]">Open module</button>
+      </footer>
+    </div>
   </section>
 </aside>

--- a/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.scss
@@ -1,92 +1,155 @@
-:host {
-  width: 260px;
-  display: inline-block;
-}
-
 .sidebar {
-  position: sticky; // stays fixed as you scroll
-  top: 0;
-  width: 260px;
-  min-height: 100vh;
-  background-color: #f9fafb; // light neutral background
-  border-right: 1px solid #e5e7eb;
-  padding: 1.5rem 1rem;
-  box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
+  padding: 2rem 1.5rem;
+  background: linear-gradient(180deg, #f6f7ff 0%, #ffffff 40%);
+  border-right: 1px solid rgba(95, 110, 252, 0.1);
+  height: 100%;
 
   .brand {
-    font-size: 1.4rem;
-    font-weight: 700;
-    color: #111827;
-    text-align: left;
-  }
+    background: #3847d0;
+    color: #fff;
+    border-radius: 18px;
+    padding: 1.5rem;
+    box-shadow: 0 20px 40px rgba(56, 71, 208, 0.25);
 
-  nav {
-    .section-title {
-      font-size: 0.85rem;
-      text-transform: uppercase;
-      font-weight: 600;
-      color: #6b7280;
-      margin-bottom: 0.5rem;
-      letter-spacing: 0.05em;
+    h2 {
+      margin: 0;
     }
 
-    ul {
-      list-style: none;
-      padding: 0;
+    p {
+      opacity: 0.82;
+      margin: 0.75rem 0 1.5rem;
+    }
+
+    .cta {
+      width: 100%;
+      border: none;
+      padding: 0.75rem 1.25rem;
+      border-radius: 14px;
+      background: #fff;
+      color: #3847d0;
+      font-weight: 600;
+      cursor: pointer;
+    }
+  }
+
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    h3 {
       margin: 0;
+      font-size: 1rem;
+      color: #4a4f68;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+  }
 
-      li {
-        margin: 0.3rem 0;
+  .folder-pill {
+    border: none;
+    background: #fff;
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    box-shadow: 0 12px 20px rgba(45, 53, 126, 0.12);
 
-        a {
-          display: block;
-          padding: 0.4rem 0.6rem;
-          color: #374151;
-          text-decoration: none;
-          border-radius: 0.375rem;
-          transition:
-            background-color 0.2s,
-            color 0.2s;
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: #5f6efc;
+    }
+  }
 
-          &:hover,
-          &.active {
-            background-color: #e5e7eb;
-            color: #111827;
-          }
+  .folder-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    .folder {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+      background: rgba(95, 110, 252, 0.08);
+      cursor: pointer;
+
+      .icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 12px;
+        display: grid;
+        place-items: center;
+        color: #fff;
+      }
+
+      .copy {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+
+        strong {
+          margin: 0;
+        }
+
+        span {
+          font-size: 0.8rem;
+          color: #6f768a;
         }
       }
     }
   }
 
-  .help {
-    margin-top: auto; // push to bottom of sidebar
+  .module {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: 0 18px 36px rgba(45, 53, 126, 0.12);
 
-    h4 {
-      font-size: 0.9rem;
-      font-weight: 600;
-      color: #6b7280;
-      margin-bottom: 0.5rem;
+    header {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+
+      .colour {
+        width: 12px;
+        height: 40px;
+        border-radius: 6px;
+        background: #4ac6b7;
+      }
+
+      strong {
+        display: block;
+      }
+
+      small {
+        color: #6f768a;
+      }
     }
 
-    ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
+    footer {
+      display: flex;
+      justify-content: flex-end;
 
-      li {
-        margin: 0.25rem 0;
-
-        a {
-          color: #2563eb;
-          text-decoration: none;
-
-          &:hover {
-            text-decoration: underline;
-          }
-        }
+      .ghost {
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        background: rgba(95, 110, 252, 0.12);
+        cursor: pointer;
+        color: #3847d0;
+        font-weight: 600;
       }
     }
   }

--- a/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.ts
@@ -1,27 +1,23 @@
-import { Component } from '@angular/core';
+import { AsyncPipe, CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { CommonModule } from '@angular/common';
+import { KbService } from '../kb.service';
+import { KnowledgeFolder } from '../models/folder.model';
 
 @Component({
   selector: 'app-kb-sidebar',
   templateUrl: './kb-sidebar.component.html',
   styleUrls: ['./kb-sidebar.component.scss'],
-  imports: [RouterModule, CommonModule],
+  imports: [RouterModule, CommonModule, AsyncPipe],
 })
 export class KbSidebarComponent {
-  categories = [
-    {
-      name: 'Getting Started',
-      slug: 'getting-started',
-      children: [
-        { id: 'intro', title: 'Introduction' },
-        { id: 'setup', title: 'Setup Guide' },
-      ],
-    },
-    {
-      name: 'Deployment',
-      slug: 'deployment',
-      children: [{ id: 'hosting', title: 'Hosting Options' }],
-    },
-  ];
+  private readonly kb = inject(KbService);
+
+  readonly folders$ = this.kb.listFolders();
+  readonly favourites$ = this.kb.favouriteFolders();
+  readonly modules$ = this.kb.listTrainingModules();
+
+  selectFolder(folder: KnowledgeFolder) {
+    this.kb.updateFilters({ folderId: folder.id });
+  }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-submit-article/kb-submit-article.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-submit-article/kb-submit-article.component.html
@@ -1,57 +1,94 @@
-<div class="submit-article">
-  <h2>Submit an Article</h2>
+<div class="submit-shell">
+  <header>
+    <h1>Create a classroom-ready article</h1>
+    <p>Craft content, attach resources, and define release gates so onboarding flows step-by-step.</p>
+  </header>
 
-  <form [formGroup]="form" (ngSubmit)="submit()">
-    <!-- Title -->
-    <label>
-      Title
-      <input type="text" formControlName="title" placeholder="Enter title" />
-    </label>
-    <div
-      class="error"
-      *ngIf="form.controls['title'].invalid && form.controls['title'].touched"
-    >
-      Title is required and must be under 150 characters.
-    </div>
+  <form [formGroup]="form" (ngSubmit)="submit()" class="article-form">
+    <section>
+      <label>Title<input type="text" formControlName="title" placeholder="Article headline" /></label>
+      <div class="field-grid">
+        <label>Slug<input type="text" formControlName="slug" placeholder="unique-article-slug" /></label>
+        <label>
+          Folder
+          <select formControlName="folderId">
+            <option value="" disabled>Select folder</option>
+            <option *ngFor="let folder of (folders$ | async)" [value]="folder.id">{{ folder.name }}</option>
+          </select>
+        </label>
+        <label>Estimated mins<input type="number" formControlName="estimatedReadMins" min="1" /></label>
+        <label>
+          Status
+          <select formControlName="status">
+            <option value="draft">Draft</option>
+            <option value="pending_review">Pending review</option>
+            <option value="scheduled">Scheduled</option>
+            <option value="published">Published</option>
+          </select>
+        </label>
+      </div>
+      <label>Hero image URL<input type="url" formControlName="heroImage" /></label>
+      <label>Excerpt<textarea formControlName="excerpt" rows="3"></textarea></label>
+      <label>
+        Body
+        <textarea formControlName="body" rows="10" placeholder="Use markdown or HTML to structure your lesson"></textarea>
+      </label>
+      <label>
+        Tags
+        <input
+          type="text"
+          placeholder="tag1, tag2"
+          [value]="(form.value.tags || []).join(', ')"
+          (change)="onTagInput($event)"
+        />
+      </label>
+    </section>
 
-    <!-- Excerpt -->
-    <label>
-      Excerpt
-      <textarea
-        formControlName="excerpt"
-        placeholder="Short summary (optional)"
-      ></textarea>
-    </label>
+    <section class="attachments">
+      <h2>Attachments</h2>
+      <input type="file" multiple (change)="onAttachmentSelected($event)" />
+      <ul>
+        <li *ngFor="let attachment of attachments">{{ attachment.name }} — {{ attachment.type }}</li>
+      </ul>
+    </section>
 
-    <!-- Body -->
-    <label>
-      Body
-      <textarea
-        formControlName="body"
-        placeholder="Full article content"
-      ></textarea>
-    </label>
-    <div
-      class="error"
-      *ngIf="form.controls['body'].invalid && form.controls['body'].touched"
-    >
-      Body is required.
-    </div>
+    <section>
+      <h2>Release sequencing</h2>
+      <div [formGroup]="form.controls['releaseRule']">
+        <label>Sequence order<input type="number" formControlName="sequenceIndex" /></label>
+        <label>
+          Requires article IDs
+          <input
+            type="text"
+            placeholder="article-1, article-2"
+            (change)="form.controls['releaseRule'].patchValue({ requiresArticles: ($event.target as HTMLInputElement).value.split(',').map(v => v.trim()).filter(Boolean) })"
+          />
+        </label>
+        <label>
+          Requires quiz IDs
+          <input
+            type="text"
+            placeholder="quiz-1"
+            (change)="form.controls['releaseRule'].patchValue({ requiresQuizzes: ($event.target as HTMLInputElement).value.split(',').map(v => v.trim()).filter(Boolean) })"
+          />
+        </label>
+      </div>
+    </section>
 
-    <!-- Tags -->
-    <label>
-      Tags (comma separated)
-      <input
-        type="text"
-        formControlName="tags"
-        placeholder="e.g. setup, deployment"
-      />
-    </label>
+    <section>
+      <h2>Checklist</h2>
+      <button type="button" class="ghost" (click)="addChecklistItem()">+ Add item</button>
+      <div class="checklist" formArrayName="checklist">
+        <div class="item" *ngFor="let group of checklist.controls; let i = index" [formGroupName]="i">
+          <input type="text" formControlName="label" placeholder="e.g. Confirm equipment tagged" />
+          <button type="button" (click)="removeChecklistItem(i)">Remove</button>
+        </div>
+      </div>
+    </section>
 
-    <button type="submit" [disabled]="isSubmitting || form.invalid">
-      {{ isSubmitting ? "Submitting…" : "Submit Article" }}
-    </button>
+    <footer>
+      <button type="submit" [disabled]="form.invalid || isSubmitting">{{ isSubmitting ? 'Saving…' : 'Save article' }}</button>
+      <span class="message" *ngIf="message">{{ message }}</span>
+    </footer>
   </form>
-
-  <p class="message" *ngIf="message">{{ message }}</p>
 </div>

--- a/src/app/knowledge-base/knowledge-component/kb-submit-article/kb-submit-article.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-submit-article/kb-submit-article.component.scss
@@ -1,74 +1,123 @@
-.submit-article {
-  max-width: 600px;
-  margin: 2rem auto;
-  padding: 2rem;
-  background: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+.submit-shell {
+  background: #fff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 22px 44px rgba(42, 51, 142, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 
-  h2 {
-    text-align: center;
-    margin-bottom: 1.5rem;
-    color: #111827;
+  header {
+    h1 {
+      margin: 0;
+    }
+
+    p {
+      margin: 0.75rem 0 0;
+      color: #5f6575;
+    }
   }
 
-  form {
+  .article-form {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 2rem;
+
+    section {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
 
     label {
       display: flex;
       flex-direction: column;
       font-weight: 600;
-      color: #374151;
+      gap: 0.4rem;
 
       input,
+      select,
       textarea {
-        margin-top: 0.25rem;
-        padding: 0.6rem 0.75rem;
-        border: 1px solid #d1d5db;
-        border-radius: 4px;
-        font-size: 0.95rem;
-        resize: vertical;
-      }
-
-      textarea {
-        min-height: 100px;
+        border-radius: 14px;
+        border: 1px solid rgba(95, 110, 252, 0.25);
+        padding: 0.75rem 1rem;
+        font-family: inherit;
       }
     }
 
-    button {
+    .field-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+
+    .attachments {
+      background: rgba(95, 110, 252, 0.08);
+      padding: 1rem 1.25rem;
+      border-radius: 18px;
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 0.4rem;
+      }
+    }
+
+    .ghost {
       align-self: flex-start;
-      background: #2563eb;
-      color: #fff;
       border: none;
-      padding: 0.6rem 1.2rem;
-      border-radius: 4px;
+      padding: 0.5rem 1rem;
+      border-radius: 999px;
+      background: rgba(95, 110, 252, 0.15);
+      color: #3847d0;
       cursor: pointer;
-      font-size: 1rem;
-      transition: background 0.2s;
+      font-weight: 600;
+    }
 
-      &:hover:not(:disabled) {
-        background: #1e40af;
-      }
+    .checklist {
+      display: grid;
+      gap: 0.75rem;
 
-      &:disabled {
-        background: #93c5fd;
-        cursor: not-allowed;
+      .item {
+        display: flex;
+        gap: 0.75rem;
+
+        input {
+          flex: 1;
+        }
+
+        button {
+          border: none;
+          border-radius: 12px;
+          padding: 0.5rem 0.75rem;
+          background: rgba(244, 67, 54, 0.12);
+          color: #c62828;
+          cursor: pointer;
+        }
       }
     }
 
-    .error {
-      color: #dc2626;
-      font-size: 0.85rem;
-    }
-  }
+    footer {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
 
-  .message {
-    margin-top: 1rem;
-    font-weight: 600;
-    text-align: center;
+      button[type='submit'] {
+        background: #3847d0;
+        color: #fff;
+        border: none;
+        border-radius: 14px;
+        padding: 0.75rem 1.75rem;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 18px 30px rgba(56, 71, 208, 0.24);
+      }
+
+      .message {
+        color: #3847d0;
+      }
+    }
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-submit-article/kb-submit-article.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-submit-article/kb-submit-article.component.ts
@@ -1,60 +1,121 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import {
-  FormBuilder,
-  FormGroup,
-  Validators,
-  ReactiveFormsModule,
-} from '@angular/forms';
+import { AsyncPipe, CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormArray, FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
 import { KbService } from '../kb.service';
-import { Article } from '../models/article.model';
+import { lastValueFrom } from 'rxjs';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { Article, ArticleAttachment } from '../models/article.model';
 
 @Component({
   selector: 'app-submit-article',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, AsyncPipe],
   templateUrl: './kb-submit-article.component.html',
   styleUrls: ['./kb-submit-article.component.scss'],
 })
 export class KbSubmitArticleComponent {
-  form: FormGroup;
+  private readonly fb = inject(FormBuilder);
+  private readonly kb = inject(KbService);
+  private readonly router = inject(Router);
+
+  readonly folders$ = this.kb.listFolders();
+  readonly form = this.fb.group({
+    title: ['', [Validators.required, Validators.maxLength(150)]],
+    slug: ['', [Validators.required]],
+    folderId: ['', Validators.required],
+    excerpt: ['', [Validators.maxLength(300)]],
+    body: ['', Validators.required],
+    tags: [[] as string[]],
+    heroImage: [''],
+    estimatedReadMins: [10, [Validators.min(1)]],
+    status: ['pending_review'],
+    releaseRule: this.fb.group({
+      sequenceIndex: [null],
+      requiresArticles: [[] as string[]],
+      requiresQuizzes: [[] as string[]],
+    }),
+    checklist: this.fb.array<FormGroup>([]),
+  });
+
+  attachments: ArticleAttachment[] = [];
   isSubmitting = false;
   message = '';
+  private slugManuallyEdited = false;
 
-  constructor(
-    private fb: FormBuilder,
-    private kb: KbService,
-  ) {
-    this.form = this.fb.group({
-      title: ['', [Validators.required, Validators.maxLength(150)]],
-      excerpt: ['', [Validators.maxLength(300)]],
-      body: ['', Validators.required], // Matches Article.body
-      tags: [''],
-    });
+  get checklist(): FormArray<FormGroup> {
+    return this.form.get('checklist') as FormArray<FormGroup>;
+  }
+
+  addChecklistItem() {
+    this.checklist.push(
+      this.fb.group({
+        id: [crypto.randomUUID()],
+        label: ['', Validators.required],
+      }),
+    );
+  }
+
+  removeChecklistItem(index: number) {
+    this.checklist.removeAt(index);
+  }
+
+  onTagInput(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    const tags = value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+    this.form.patchValue({ tags });
+  }
+
+  async onAttachmentSelected(event: Event) {
+    const files = (event.target as HTMLInputElement).files;
+    if (!files?.length) return;
+    const articleId = this.form.getRawValue().slug || crypto.randomUUID();
+    this.form.patchValue({ slug: articleId });
+    for (const file of Array.from(files)) {
+      try {
+        const attachment = await lastValueFrom(this.kb.uploadAttachment(articleId, file));
+        if (attachment) {
+          this.attachments.push(attachment);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
   }
 
   submit(): void {
     if (this.form.invalid || this.isSubmitting) return;
 
+    const id = this.form.value.slug || crypto.randomUUID();
+    const article: Partial<Article> = {
+      id,
+      slug: this.form.value.slug || id,
+      title: this.form.value.title ?? '',
+      folderId: this.form.value.folderId ?? '',
+      excerpt: this.form.value.excerpt ?? undefined,
+      body: this.form.value.body ?? '',
+      tags: this.form.value.tags ?? [],
+      heroImage: this.form.value.heroImage ?? undefined,
+      estimatedReadMins: this.form.value.estimatedReadMins ?? 10,
+      status: (this.form.value.status as Article['status']) ?? 'pending_review',
+      releaseRule: this.form.value.releaseRule ?? undefined,
+      checklist: this.checklist.value as Article['checklist'],
+      attachments: this.attachments,
+    } as Article;
+
     this.isSubmitting = true;
     this.message = '';
 
-    const article: Article = {
-      id: this.generateUUID(), // or use a UUID generator
-      title: this.form.value.title,
-      excerpt: this.form.value.excerpt || undefined,
-      body: this.form.value.body,
-      tags: this.form.value.tags
-        ? this.form.value.tags.split(',').map((t: string) => t.trim())
-        : [],
-      updated_at: new Date().toISOString(),
-    };
-
-    this.kb.add(article).subscribe({
+    this.kb.upsertArticle(article).subscribe({
       next: () => {
-        this.message = '✅ Article submitted successfully!';
-        this.form.reset();
+        this.message = '✅ Article saved. It will appear once approved.';
+        this.form.reset({ status: 'pending_review', estimatedReadMins: 10, tags: [] });
+        this.attachments = [];
         this.isSubmitting = false;
+        this.router.navigate(['/kb']);
       },
       error: (err) => {
         console.error(err);
@@ -64,8 +125,28 @@ export class KbSubmitArticleComponent {
     });
   }
 
-  /** Create a URL-safe slug for the article ID */
-  private generateUUID(): string {
-    return crypto.randomUUID();
+  constructor() {
+    const titleControl = this.form.get('title');
+    const slugControl = this.form.get('slug');
+
+    slugControl?.valueChanges.subscribe(() => {
+      this.slugManuallyEdited = true;
+    });
+
+    titleControl
+      ?.valueChanges.pipe(debounceTime(200), distinctUntilChanged())
+      .subscribe((title) => {
+        if (!this.slugManuallyEdited) {
+          slugControl?.setValue(this.slugify(title ?? ''), { emitEvent: false });
+        }
+      });
+  }
+
+  private slugify(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)+/g, '')
+      .substring(0, 80);
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-training/kb-training.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-training/kb-training.component.html
@@ -1,0 +1,33 @@
+<div class="training-hero">
+  <h1>Training playlists</h1>
+  <p>Admin curated journeys unlock as employees complete required lessons.</p>
+</div>
+
+<div class="progress" *ngIf="(progress$ | async) as progress">
+  <div class="stat">
+    <strong>{{ progress.completedArticles.length }}</strong>
+    <span>Articles completed</span>
+  </div>
+  <div class="stat">
+    <strong>{{ progress.quizAttempts.length }}</strong>
+    <span>Quizzes attempted</span>
+  </div>
+  <div class="stat">
+    <strong>{{ progress.acknowledgedArticles.length }}</strong>
+    <span>Acknowledged</span>
+  </div>
+</div>
+
+<section class="module-list" *ngIf="(modules$ | async) as modules">
+  <article class="module" *ngFor="let module of modules; trackBy: trackModule">
+    <header>
+      <h2>{{ module.title }}</h2>
+      <span class="meta">{{ module.articleIds.length }} lessons • {{ module.quizIds.length }} quizzes</span>
+    </header>
+    <p>{{ module.description }}</p>
+    <footer>
+      <a [routerLink]="['/kb']" class="cta">View lessons</a>
+      <span class="due" *ngIf="module.dueDate">Due {{ module.dueDate | date: 'mediumDate' }}</span>
+    </footer>
+  </article>
+</section>

--- a/src/app/knowledge-base/knowledge-component/kb-training/kb-training.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-training/kb-training.component.scss
@@ -1,0 +1,79 @@
+.training-hero {
+  background: linear-gradient(135deg, #4ac6b7, #5f6efc);
+  border-radius: 22px;
+  padding: 2rem;
+  color: #fff;
+  margin-bottom: 1.5rem;
+
+  h1 {
+    margin: 0 0 0.5rem;
+  }
+}
+
+.progress {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+
+  .stat {
+    background: #fff;
+    border-radius: 18px;
+    padding: 1rem 1.5rem;
+    box-shadow: 0 16px 30px rgba(42, 51, 142, 0.12);
+    display: grid;
+    gap: 0.25rem;
+
+    strong {
+      font-size: 1.6rem;
+    }
+
+    span {
+      color: #5f6575;
+      font-size: 0.85rem;
+    }
+  }
+}
+
+.module-list {
+  display: grid;
+  gap: 1.5rem;
+
+  .module {
+    background: #fff;
+    border-radius: 20px;
+    padding: 1.75rem;
+    box-shadow: 0 20px 36px rgba(42, 51, 142, 0.12);
+    display: grid;
+    gap: 1rem;
+
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+
+      .meta {
+        color: #6f768a;
+      }
+    }
+
+    footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .cta {
+        background: #3847d0;
+        color: #fff;
+        padding: 0.6rem 1.2rem;
+        border-radius: 14px;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .due {
+        color: #5f6575;
+        font-size: 0.85rem;
+      }
+    }
+  }
+}

--- a/src/app/knowledge-base/knowledge-component/kb-training/kb-training.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-training/kb-training.component.ts
@@ -1,0 +1,23 @@
+import { AsyncPipe, CommonModule, DatePipe, NgFor, NgIf } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { KbService } from '../kb.service';
+import { TrainingModule } from '../models/training.model';
+
+@Component({
+  selector: 'app-kb-training',
+  standalone: true,
+  templateUrl: './kb-training.component.html',
+  styleUrls: ['./kb-training.component.scss'],
+  imports: [CommonModule, AsyncPipe, RouterModule, NgFor, NgIf, DatePipe],
+})
+export class KbTrainingComponent {
+  private readonly kb = inject(KbService);
+
+  readonly modules$ = this.kb.listTrainingModules();
+  readonly progress$ = this.kb.getTrainingProgress();
+
+  trackModule(_: number, module: TrainingModule) {
+    return module.id;
+  }
+}

--- a/src/app/knowledge-base/knowledge-component/kb.service.ts
+++ b/src/app/knowledge-base/knowledge-component/kb.service.ts
@@ -1,51 +1,198 @@
 import { Injectable } from '@angular/core';
-import { Observable, from } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { Article } from './models/article.model';
+import { BehaviorSubject, Observable, combineLatest, from, map, of } from 'rxjs';
+import {
+  Article,
+  ArticleAttachment,
+  ArticleComment,
+  ArticleStatus,
+  ArticleWithRelations,
+  ArticleQuiz,
+} from './models/article.model';
+import { KnowledgeFolder } from './models/folder.model';
+import {
+  AdminDashboardSnapshot,
+  QuizAttempt,
+  TrainingModule,
+  TrainingProgress,
+} from './models/training.model';
+import { KnowledgeViewMode } from './models/view-mode.type';
 import { dbFunctionsService } from '../../shared/supabase-service/db_functions.service';
+
+interface KnowledgeBaseFilters {
+  folderId?: string | null;
+  tag?: string | null;
+  status?: ArticleStatus | 'all';
+  favouritesOnly?: boolean;
+  term?: string | null;
+}
 
 @Injectable({
   providedIn: 'root',
 })
 export class KbService {
+  private readonly filters$ = new BehaviorSubject<KnowledgeBaseFilters>({ status: 'published' });
+  private readonly viewMode$ = new BehaviorSubject<KnowledgeViewMode>('grid');
+
   constructor(private dbFunctions: dbFunctionsService) {}
 
-  // Get all articles
+  // region ─── Article Queries ────────────────────────────────────────────────
+
   list(): Observable<Article[]> {
-    // Convert the Promise returned by getArticles() into an Observable
-    return from(this.dbFunctions.getArticles()).pipe(
-      map((data) => data as Article[]),
-    );
-  }
-
-  // Get one article by ID
-  get(id: string): Observable<Article | undefined> {
-    return from(this.dbFunctions.getArticleById(id)).pipe(
-      map((data) => data as Article | undefined),
-    );
-  }
-
-  // Search articles
-  search(q: string): Observable<Article[]> {
-    if (!q?.trim()) return this.list();
-    const term = q.toLowerCase().trim();
-
-    return this.list().pipe(
-      map((articles) =>
-        articles.filter(
-          (a) =>
-            a.title.toLowerCase().includes(term) ||
-            (a.excerpt ?? '').toLowerCase().includes(term) ||
-            a.tags?.some((t) => t.toLowerCase().includes(term)),
-        ),
+    return combineLatest([
+      from(this.dbFunctions.getArticlesWithMeta()),
+      this.filters$,
+    ]).pipe(
+      map(([articles, filters]) =>
+        articles.filter((article) => {
+          if (filters.status && filters.status !== 'all' && article.status !== filters.status) {
+            return false;
+          }
+          if (filters.folderId && article.folderId !== filters.folderId) {
+            return false;
+          }
+          if (filters.tag && !(article.tags ?? []).includes(filters.tag)) {
+            return false;
+          }
+          if (filters.favouritesOnly && !article.isFavourite) {
+            return false;
+          }
+          if (filters.term) {
+            const haystack = `${article.title} ${article.excerpt ?? ''} ${(article.tags ?? []).join(' ')}`.toLowerCase();
+            if (!haystack.includes(filters.term.toLowerCase())) {
+              return false;
+            }
+          }
+          return true;
+        }),
       ),
     );
   }
 
-  // Add a new article
-  add(article: Article): Observable<Article> {
-    return from(this.dbFunctions.addArticle(article)).pipe(
-      map((data) => data as Article),
+  get(idOrSlug: string): Observable<ArticleWithRelations | undefined> {
+    if (!idOrSlug) return of(undefined);
+    return from(this.dbFunctions.getArticleDetail(idOrSlug)).pipe(
+      map((data) => data ?? undefined),
     );
   }
+
+  search(term: string): Observable<Article[]> {
+    return from(this.dbFunctions.searchArticles(term));
+  }
+
+  upsertArticle(article: Partial<Article> & { id?: string }): Observable<Article> {
+    return from(this.dbFunctions.upsertArticle(article)).pipe(map((data) => data as Article));
+  }
+
+  updateFilters(filters: Partial<KnowledgeBaseFilters>): void {
+    this.filters$.next({ ...this.filters$.value, ...filters });
+  }
+
+  filtersChanges(): Observable<KnowledgeBaseFilters> {
+    return this.filters$.asObservable();
+  }
+
+  setViewMode(mode: KnowledgeViewMode): void {
+    this.viewMode$.next(mode);
+  }
+
+  viewModeChanges(): Observable<KnowledgeViewMode> {
+    return this.viewMode$.asObservable();
+  }
+
+  addComment(articleId: string, body: string, mentions: string[], parentId?: string): Observable<ArticleComment> {
+    return from(
+      this.dbFunctions.createArticleComment({ articleId, body, mentions, parentId }),
+    ).pipe(map((data) => data as ArticleComment));
+  }
+
+  toggleFavourite(articleId: string): Observable<{ isFavourite: boolean }> {
+    return from(this.dbFunctions.toggleFavouriteArticle(articleId));
+  }
+
+  acknowledgeArticle(articleId: string): Observable<{ acknowledgedAt: string }> {
+    return from(this.dbFunctions.acknowledgeArticle(articleId));
+  }
+
+  recordArticleProgress(articleId: string, completed: boolean): Observable<void> {
+    return from(this.dbFunctions.recordArticleProgress(articleId, completed));
+  }
+
+  uploadAttachment(articleId: string, file: File): Observable<ArticleAttachment> {
+    return from(this.dbFunctions.uploadKnowledgeAttachment(articleId, file));
+  }
+
+  // endregion
+
+  // region ─── Folders & Navigation ──────────────────────────────────────────
+
+  listFolders(): Observable<KnowledgeFolder[]> {
+    return from(this.dbFunctions.getKnowledgeFolders());
+  }
+
+  favouriteFolders(): Observable<KnowledgeFolder[]> {
+    return this.listFolders().pipe(
+      map((folders) => folders.filter((folder) => (folder.progressPct ?? 0) >= 80)),
+    );
+  }
+
+  // endregion
+
+  // region ─── Training & Quizzes ────────────────────────────────────────────
+
+  listTrainingModules(): Observable<TrainingModule[]> {
+    return from(this.dbFunctions.getTrainingModules());
+  }
+
+  getQuiz(quizId: string): Observable<ArticleQuiz | undefined> {
+    return from(this.dbFunctions.getQuiz(quizId)).pipe(map((data) => data ?? undefined));
+  }
+
+  submitQuizAttempt(quizId: string, responses: Record<string, unknown>): Observable<QuizAttempt> {
+    return from(this.dbFunctions.submitQuizAttempt(quizId, responses));
+  }
+
+  getTrainingProgress(userId?: string): Observable<TrainingProgress> {
+    return from(this.dbFunctions.getTrainingProgress(userId));
+  }
+
+  getAdminSnapshot(): Observable<AdminDashboardSnapshot> {
+    return from(this.dbFunctions.getKnowledgeAdminSnapshot());
+  }
+
+  releaseArticles(payload: { articleIds: string[]; userIds?: string[]; teamIds?: string[] }): Observable<void> {
+    return from(this.dbFunctions.releaseArticles(payload));
+  }
+
+  // endregion
+
+  // region ─── Helpers ───────────────────────────────────────────────────────
+
+  buildTimelineGrouping(articles$: Observable<Article[]>): Observable<
+    { period: string; articles: Article[] }[]
+  > {
+    return articles$.pipe(
+      map((articles) =>
+        Object.entries(
+          articles.reduce<Record<string, Article[]>>((acc, article) => {
+            const date = new Date(article.createdAt);
+            const period = new Intl.DateTimeFormat('en-US', {
+              month: 'long',
+              year: 'numeric',
+            }).format(date);
+            acc[period] = acc[period] ?? [];
+            acc[period].push(article);
+            return acc;
+          }, {}),
+        )
+          .map(([period, list]) => ({ period, articles: list }))
+          .sort(
+            (a, b) =>
+              new Date(b.articles[0].createdAt).getTime() -
+              new Date(a.articles[0].createdAt).getTime(),
+          ),
+      ),
+    );
+  }
+
+  // endregion
 }

--- a/src/app/knowledge-base/knowledge-component/knowledge-base.routes.ts
+++ b/src/app/knowledge-base/knowledge-component/knowledge-base.routes.ts
@@ -3,6 +3,8 @@ import { KbListComponent } from './kb-list/kb-list.component';
 import { KbArticleComponent } from './kb-article/kb-article.component';
 import { KnowledgeShellComponent } from './kb-shell/knowledge-shell.component';
 import { KbSubmitArticleComponent } from './kb-submit-article/kb-submit-article.component';
+import { KbTrainingComponent } from './kb-training/kb-training.component';
+import { KbAdminDashboardComponent } from './kb-admin-dashboard/kb-admin-dashboard.component';
 
 export const KnowledgeBaseRoutes: Routes = [
   {
@@ -12,6 +14,8 @@ export const KnowledgeBaseRoutes: Routes = [
       { path: 'article/:id', component: KbArticleComponent },
       { path: '', component: KbListComponent },
       { path: 'submit-article', component: KbSubmitArticleComponent },
+      { path: 'training', component: KbTrainingComponent },
+      { path: 'admin', component: KbAdminDashboardComponent },
     ],
   },
 ];

--- a/src/app/knowledge-base/knowledge-component/models/article.model.ts
+++ b/src/app/knowledge-base/knowledge-component/models/article.model.ts
@@ -1,8 +1,105 @@
+export type ArticleStatus = 'draft' | 'pending_review' | 'scheduled' | 'published' | 'archived';
+
+export interface ArticleAttachment {
+  id: string;
+  articleId: string;
+  name: string;
+  type: 'file' | 'image' | 'link';
+  url: string;
+  size?: number;
+  uploadedAt: string;
+  uploadedBy: string;
+}
+
+export interface ArticleReleaseRule {
+  /** Optional sequence number that defines the order the article unlocks in a playlist */
+  sequenceIndex?: number;
+  /** Article ids that must be completed before this one unlocks */
+  requiresArticles?: string[];
+  /** Quiz ids that must be passed before this article unlocks */
+  requiresQuizzes?: string[];
+}
+
+export interface ArticleAudience {
+  /** Org unit or team ids that can see the article */
+  teams?: string[];
+  /** Specific user ids */
+  users?: string[];
+  /** Job titles or roles */
+  roles?: string[];
+}
+
+export interface ArticleChecklistItem {
+  id: string;
+  label: string;
+  completedBy?: string[];
+}
+
 export interface Article {
   id: string;
+  slug: string;
+  folderId: string;
   title: string;
+  heroImage?: string;
   excerpt?: string;
   body: string;
   tags?: string[];
-  updated_at?: string; // ISO date
+  attachments?: ArticleAttachment[];
+  status: ArticleStatus;
+  releaseRule?: ArticleReleaseRule;
+  audience?: ArticleAudience;
+  checklist?: ArticleChecklistItem[];
+  estimatedReadMins?: number;
+  createdAt: string;
+  updatedAt: string;
+  authorId: string;
+  authorName?: string;
+  isFavourite?: boolean;
+}
+
+export interface ArticleWithRelations extends Article {
+  comments: ArticleComment[];
+  relatedArticles: Article[];
+  quiz?: ArticleQuiz;
+}
+
+export interface ArticleComment {
+  id: string;
+  articleId: string;
+  authorId: string;
+  authorName: string;
+  avatarUrl?: string;
+  body: string;
+  mentions?: string[];
+  attachments?: ArticleAttachment[];
+  createdAt: string;
+  resolvedAt?: string;
+  parentId?: string;
+  replies?: ArticleComment[];
+}
+
+export interface ArticleQuiz {
+  id: string;
+  articleId: string;
+  title: string;
+  summary?: string;
+  passingScore: number;
+  questions: QuizQuestion[];
+}
+
+export type QuizQuestionType = 'single' | 'multi' | 'true_false' | 'short_text';
+
+export interface QuizQuestionChoice {
+  id: string;
+  label: string;
+  correct?: boolean;
+  explanation?: string;
+}
+
+export interface QuizQuestion {
+  id: string;
+  prompt: string;
+  type: QuizQuestionType;
+  choices?: QuizQuestionChoice[];
+  maxSelections?: number;
 }

--- a/src/app/knowledge-base/knowledge-component/models/folder.model.ts
+++ b/src/app/knowledge-base/knowledge-component/models/folder.model.ts
@@ -1,0 +1,13 @@
+export interface KnowledgeFolder {
+  id: string;
+  name: string;
+  description?: string;
+  colour?: string;
+  icon?: string;
+  parentId?: string;
+  articleCount: number;
+  unreadCount: number;
+  completedCount: number;
+  progressPct?: number;
+  children?: KnowledgeFolder[];
+}

--- a/src/app/knowledge-base/knowledge-component/models/training.model.ts
+++ b/src/app/knowledge-base/knowledge-component/models/training.model.ts
@@ -1,0 +1,61 @@
+import { ArticleQuiz } from './article.model';
+
+export interface TrainingModule {
+  id: string;
+  title: string;
+  description?: string;
+  folderId?: string;
+  articleIds: string[];
+  quizIds: string[];
+  estimatedMinutes?: number;
+  colour?: string;
+  dueDate?: string;
+}
+
+export interface QuizAttempt {
+  id: string;
+  quizId: string;
+  userId: string;
+  score: number;
+  submittedAt: string;
+  responses: QuizAttemptResponse[];
+  passed: boolean;
+}
+
+export interface QuizAttemptResponse {
+  questionId: string;
+  answer: string[] | string | boolean | null;
+}
+
+export interface TrainingProgress {
+  userId: string;
+  completedArticles: string[];
+  acknowledgedArticles: string[];
+  quizAttempts: QuizAttempt[];
+  lastSync: string;
+}
+
+export interface UserSummaryProgress {
+  userId: string;
+  fullName: string;
+  avatarUrl?: string;
+  latestLogin?: string;
+  completedArticles: number;
+  totalArticles: number;
+  completedQuizzes: number;
+  averageScore?: number;
+  outstandingArticles: number;
+  outstandingQuizzes: number;
+}
+
+export interface AdminDashboardSnapshot {
+  totalArticles: number;
+  totalDrafts: number;
+  totalUsers: number;
+  activeTrainingModules: number;
+  averageCompletion: number;
+  topPerformers: UserSummaryProgress[];
+  atRiskUsers: UserSummaryProgress[];
+  modules: TrainingModule[];
+  quizzes: ArticleQuiz[];
+}

--- a/src/app/knowledge-base/knowledge-component/models/view-mode.type.ts
+++ b/src/app/knowledge-base/knowledge-component/models/view-mode.type.ts
@@ -1,0 +1,1 @@
+export type KnowledgeViewMode = 'grid' | 'timeline' | 'folders';

--- a/src/app/shared/supabase-service/db_functions.service.ts
+++ b/src/app/shared/supabase-service/db_functions.service.ts
@@ -1,7 +1,20 @@
 // src/app/services/database-functions.service.ts
 import { Injectable } from '@angular/core';
 import { SupabaseService } from './supabase.service';
-import { Article } from '../../knowledge-base/knowledge-component/models/article.model';
+import {
+  Article,
+  ArticleAttachment,
+  ArticleWithRelations,
+  ArticleQuiz,
+  ArticleComment,
+} from '../../knowledge-base/knowledge-component/models/article.model';
+import { KnowledgeFolder } from '../../knowledge-base/knowledge-component/models/folder.model';
+import {
+  AdminDashboardSnapshot,
+  QuizAttempt,
+  TrainingModule,
+  TrainingProgress,
+} from '../../knowledge-base/knowledge-component/models/training.model';
 
 @Injectable({
   providedIn: 'root',
@@ -39,70 +52,207 @@ export class dbFunctionsService {
     }
   }
 
-  async getArticles() {
-    try {
-      const { data, error } =
-        await this.supabaseService.client.functions.invoke('database-access', {
-          headers: { 'x-query-type': 'articles' },
-        });
+  // ─── Knowledge Base Calls ─────────────────────────────────────────────────
 
-      if (error) throw error;
-      return data.data;
-    } catch (err) {
-      console.error('Error fetching functions:', err);
-      throw err;
-    }
-  }
-
-  async getArticleById(id: string) {
-    try {
-      const { data, error } =
-        await this.supabaseService.client.functions.invoke('database-access', {
-          headers: { 'x-query-type': 'articles', 'x-query-id': id },
-        });
-
-      if (error) throw error;
-      return data.data;
-    } catch (err) {
-      console.error('Error fetching functions:', err);
-      throw err;
-    }
-  }
-
-  async addArticle(article: Article) {
-    try {
-      const { data, error } =
-        await this.supabaseService.client.functions.invoke('add-article', {
-          // ✅ Just pass the article as the body
-          body: article,
-        });
-
-      if (error) throw error;
-      // If your Edge function returns { success: true } or { data: ... }
-      return data ?? null;
-    } catch (err) {
-      console.error('Error adding article:', err);
-      throw err;
-    }
-  }
-
-  // Frontend
-  async getNavigationItems() {
+  async getArticlesWithMeta(): Promise<Article[]> {
     const { data, error } = await this.supabaseService.client.functions.invoke(
-      'navbar-availability',
+      'knowledgebase-hub',
       {
-        headers: {
-          'x-query-type': 'navigation-items',
-          'x-org-slug': 'gravity', // <-- send the ACTUAL slug, e.g., 'cue' or 'rms-nz'
-        },
-        body: {},
+        headers: { 'x-query-type': 'articles-with-meta' },
+      },
+    );
+    if (error) throw error;
+    return data.articles as Article[];
+  }
+
+  async getArticleDetail(idOrSlug: string): Promise<ArticleWithRelations | null> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'article-detail', 'x-article-id': idOrSlug },
+      },
+    );
+    if (error) throw error;
+    return data.article ?? null;
+  }
+
+  async searchArticles(term: string): Promise<Article[]> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'search-articles' },
+        body: { term },
+      },
+    );
+    if (error) throw error;
+    return data.articles as Article[];
+  }
+
+  async upsertArticle(article: Partial<Article> & { id?: string }): Promise<Article> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'upsert-article' },
+        body: { article },
+      },
+    );
+    if (error) throw error;
+    return data.article as Article;
+  }
+
+  async createArticleComment(payload: {
+    articleId: string;
+    body: string;
+    mentions?: string[];
+    parentId?: string;
+  }): Promise<ArticleComment> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'create-comment' },
+        body: payload,
+      },
+    );
+    if (error) throw error;
+    return data.comment as ArticleComment;
+  }
+
+  async toggleFavouriteArticle(articleId: string): Promise<{ isFavourite: boolean }> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'toggle-favourite', 'x-article-id': articleId },
+      },
+    );
+    if (error) throw error;
+    return data as { isFavourite: boolean };
+  }
+
+  async acknowledgeArticle(articleId: string): Promise<{ acknowledgedAt: string }> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'acknowledge-article', 'x-article-id': articleId },
+      },
+    );
+    if (error) throw error;
+    return data as { acknowledgedAt: string };
+  }
+
+  async recordArticleProgress(articleId: string, completed: boolean): Promise<void> {
+    const { error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'record-progress' },
+        body: { articleId, completed },
+      },
+    );
+    if (error) throw error;
+  }
+
+  async uploadKnowledgeAttachment(articleId: string, file: File): Promise<ArticleAttachment> {
+    const form = new FormData();
+    form.append('articleId', articleId);
+    form.append('file', file);
+
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-attachments',
+      {
+        body: form,
       },
     );
 
     if (error) throw error;
-    return data.items;
+    return data.attachment as ArticleAttachment;
   }
 
+  async getKnowledgeFolders(): Promise<KnowledgeFolder[]> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'folders' },
+      },
+    );
+    if (error) throw error;
+    return data.folders as KnowledgeFolder[];
+  }
+
+  async getTrainingModules(): Promise<TrainingModule[]> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'training-modules' },
+      },
+    );
+    if (error) throw error;
+    return data.modules as TrainingModule[];
+  }
+
+  async getQuiz(quizId: string): Promise<ArticleQuiz | null> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'quiz-detail', 'x-quiz-id': quizId },
+      },
+    );
+    if (error) throw error;
+    return data.quiz ?? null;
+  }
+
+  async submitQuizAttempt(
+    quizId: string,
+    responses: Record<string, unknown>,
+  ): Promise<QuizAttempt> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'submit-quiz', 'x-quiz-id': quizId },
+        body: { responses },
+      },
+    );
+    if (error) throw error;
+    return data.attempt as QuizAttempt;
+  }
+
+  async getTrainingProgress(userId?: string): Promise<TrainingProgress> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'training-progress' },
+        body: { userId },
+      },
+    );
+    if (error) throw error;
+    return data.progress as TrainingProgress;
+  }
+
+  async getKnowledgeAdminSnapshot(): Promise<AdminDashboardSnapshot> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'admin-snapshot' },
+      },
+    );
+    if (error) throw error;
+    return data.snapshot as AdminDashboardSnapshot;
+  }
+
+  async releaseArticles(payload: {
+    articleIds: string[];
+    userIds?: string[];
+    teamIds?: string[];
+  }): Promise<void> {
+    const { error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: { 'x-query-type': 'release-articles' },
+        body: payload,
+      },
+    );
+    if (error) throw error;
+  }
+
+  // Legacy inventory demo data (kept for backwards compat)
   getItems() {
     return [
       { id: 1, name: 'test 1', category: 'light', stock: 5, price: 50 },


### PR DESCRIPTION
## Summary
- redesign the knowledge base shell, listings and article views to mirror a Google Classroom style experience with grid, timeline and folder modes
- add article creation enhancements, sidebar navigation, training hub, admin oversight dashboard, comments, attachments, release rules and quiz handling on the frontend
- provide Supabase edge functions and SQL schema to power articles, folders, releases, comments, attachments, training modules and admin analytics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff12c8fa0083238468fe5b326f7b01