### PR TITLE
feat: improve knowledge base admin controls and styling

### DIFF
--- a/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.html
@@ -1,17 +1,17 @@
 <div class="kb-dashboard" *ngIf="(stats$ | async) as stats">
   <div class="hero">
     <div class="hero-copy">
-      <h1>Knowledge classroom</h1>
-      <p>Pick up right where you left off. Your learning journey continues below.</p>
+      <h1>Knowledge overview</h1>
+      <p>Review the latest documentation, release notes, and learning content for your teams.</p>
       <div class="hero-stats">
         <div class="pill"><strong>{{ stats.total }}</strong><span>Total articles</span></div>
         <div class="pill success"><strong>{{ stats.published }}</strong><span>Published</span></div>
-        <div class="pill warning"><strong>{{ stats.drafts }}</strong><span>Drafts</span></div>
+        <div class="pill warning"><strong>{{ stats.drafts }}</strong><span>In review</span></div>
         <div class="pill neutral"><strong>{{ stats.folders }}</strong><span>Folders</span></div>
       </div>
     </div>
     <div class="hero-actions">
-      <button class="cta" routerLink="/kb/submit-article">➕ New article</button>
+      <button class="cta" routerLink="/kb/submit-article">Create article</button>
       <button class="ghost" (click)="setViewMode('grid')">Grid</button>
       <button class="ghost" (click)="setViewMode('timeline')">Timeline</button>
       <button class="ghost" (click)="setViewMode('folders')">Folders</button>

--- a/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-list/kb-list.component.scss
@@ -5,11 +5,11 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    background: linear-gradient(135deg, #5f6efc, #7f85ff);
-    color: #fff;
+    background: linear-gradient(140deg, #1f2a44, #295299);
+    color: #f6f8ff;
     border-radius: 18px;
     padding: 2.25rem;
-    box-shadow: 0 18px 40px rgba(52, 63, 189, 0.2);
+    box-shadow: 0 22px 45px rgba(15, 29, 54, 0.35);
     gap: 1.5rem;
 
     .hero-copy {
@@ -21,7 +21,7 @@
       }
 
       p {
-        opacity: 0.85;
+        opacity: 0.8;
         margin-bottom: 1.5rem;
       }
     }
@@ -32,7 +32,7 @@
       gap: 0.75rem;
 
       .pill {
-        background: rgba(255, 255, 255, 0.12);
+        background: rgba(255, 255, 255, 0.16);
         padding: 0.75rem 1rem;
         border-radius: 999px;
         display: flex;
@@ -48,15 +48,15 @@
         }
 
         &.success {
-          background: rgba(86, 235, 177, 0.24);
+          background: rgba(104, 214, 175, 0.28);
         }
 
         &.warning {
-          background: rgba(255, 196, 71, 0.28);
+          background: rgba(255, 188, 95, 0.3);
         }
 
         &.neutral {
-          background: rgba(255, 255, 255, 0.18);
+          background: rgba(255, 255, 255, 0.22);
         }
       }
     }
@@ -75,19 +75,19 @@
         transition: transform 0.12s ease, box-shadow 0.12s ease;
 
         &.cta {
-          background: #fff;
-          color: #3847d0;
-          box-shadow: 0 12px 24px rgba(16, 22, 97, 0.25);
+          background: #f6f8ff;
+          color: #1f2a44;
+          box-shadow: 0 12px 24px rgba(10, 24, 48, 0.25);
         }
 
         &.ghost {
-          background: rgba(255, 255, 255, 0.16);
-          color: #fff;
+          background: rgba(255, 255, 255, 0.18);
+          color: #f6f8ff;
         }
 
         &:hover {
           transform: translateY(-2px);
-          box-shadow: 0 16px 32px rgba(16, 22, 97, 0.25);
+          box-shadow: 0 16px 32px rgba(10, 24, 48, 0.28);
         }
       }
     }
@@ -100,15 +100,15 @@
   gap: 1.5rem;
 
   .class-card {
-    background: #fff;
+    background: #ffffff;
     border-radius: 18px;
     padding: 1.5rem;
-    box-shadow: 0 16px 30px rgba(59, 67, 160, 0.12);
+    box-shadow: 0 18px 36px rgba(28, 42, 66, 0.1);
     position: relative;
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    border-top: 6px solid rgba(95, 110, 252, 0.65);
+    border-top: 6px solid rgba(31, 95, 213, 0.65);
 
     header {
       display: flex;
@@ -126,15 +126,15 @@
         .status {
           padding: 0.25rem 0.65rem;
           border-radius: 999px;
-          background: rgba(106, 118, 255, 0.16);
+          background: rgba(31, 95, 213, 0.16);
           &.draft {
-            background: rgba(255, 173, 66, 0.2);
-            color: #c97714;
+            background: rgba(255, 188, 95, 0.22);
+            color: #915817;
           }
         }
 
         .folder {
-          background: rgba(36, 44, 136, 0.12);
+          background: rgba(31, 42, 68, 0.12);
           padding: 0.25rem 0.65rem;
           border-radius: 999px;
         }
@@ -145,7 +145,7 @@
         border: none;
         font-size: 1.35rem;
         cursor: pointer;
-        color: rgba(255, 255, 255, 0.6);
+        color: rgba(31, 42, 68, 0.3);
         transition: transform 0.15s ease;
 
         &.active {
@@ -165,7 +165,7 @@
     }
 
     p {
-      color: #5f6575;
+      color: #5b6473;
       flex-grow: 1;
     }
 
@@ -181,27 +181,27 @@
         flex-wrap: wrap;
 
         .chip {
-          background: rgba(95, 110, 252, 0.12);
+          background: rgba(31, 95, 213, 0.12);
           padding: 0.3rem 0.6rem;
           border-radius: 999px;
           font-size: 0.75rem;
-          color: #3847d0;
+          color: #1f5fd5;
         }
       }
 
       .meta {
         font-size: 0.75rem;
-        color: #8a8fa3;
+        color: #7a8496;
       }
 
       .cta {
-        background: #3847d0;
+        background: #1f5fd5;
         color: #fff;
         padding: 0.6rem 1.2rem;
         border-radius: 999px;
         text-decoration: none;
         font-weight: 600;
-        box-shadow: 0 12px 20px rgba(56, 71, 208, 0.25);
+        box-shadow: 0 12px 22px rgba(31, 95, 213, 0.22);
       }
     }
   }
@@ -213,14 +213,14 @@
   gap: 1.5rem;
 
   .timeline-group {
-    background: #fff;
+    background: #ffffff;
     border-radius: 18px;
     padding: 1.5rem;
-    box-shadow: 0 18px 40px rgba(56, 71, 208, 0.08);
+    box-shadow: 0 18px 40px rgba(26, 40, 68, 0.08);
 
     h2 {
       margin-top: 0;
-      color: #3847d0;
+      color: #1f5fd5;
     }
 
     .timeline-card {
@@ -236,7 +236,7 @@
 
       .timeline-date {
         font-weight: 600;
-        color: #5f6efc;
+        color: #1f5fd5;
         font-size: 0.95rem;
       }
 
@@ -247,7 +247,7 @@
 
         p {
           margin: 0 0 0.75rem;
-          color: #5f6575;
+          color: #5b6473;
         }
 
         .timeline-tags {
@@ -257,7 +257,7 @@
           margin-bottom: 0.75rem;
 
           span {
-            background: rgba(95, 110, 252, 0.14);
+            background: rgba(31, 95, 213, 0.16);
             padding: 0.3rem 0.65rem;
             border-radius: 999px;
             font-size: 0.75rem;
@@ -265,7 +265,7 @@
         }
 
         .cta {
-          color: #3847d0;
+          color: #1f5fd5;
           font-weight: 600;
         }
       }
@@ -279,10 +279,10 @@
   gap: 1.5rem;
 
   .folder {
-    background: #fff;
+    background: #ffffff;
     border-radius: 18px;
     padding: 1.5rem;
-    box-shadow: 0 16px 36px rgba(33, 38, 89, 0.12);
+    box-shadow: 0 16px 36px rgba(26, 40, 68, 0.12);
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -308,7 +308,7 @@
 
       p {
         margin: 0;
-        color: #6f768a;
+        color: #5b6473;
         font-size: 0.9rem;
       }
     }
@@ -321,17 +321,17 @@
 
         span {
           font-size: 0.8rem;
-          color: #80859c;
+          color: #6d768a;
         }
 
         .bar {
-          background: rgba(95, 110, 252, 0.12);
+          background: rgba(31, 95, 213, 0.12);
           height: 8px;
           border-radius: 999px;
           overflow: hidden;
 
           .fill {
-            background: #5f6efc;
+            background: #1f5fd5;
             height: 100%;
             transition: width 0.3s ease;
           }

--- a/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.html
@@ -6,10 +6,20 @@
   <div class="main-area">
     <header class="top-bar">
       <div class="title">
-        <h1>Knowledgebase</h1>
-        <p>Structured like Google Classroom – curated streams, folders and release gates.</p>
+        <h1>Knowledge base</h1>
+        <p>Curated playbooks, process updates, and training materials for your teams.</p>
       </div>
-      <app-kb-search></app-kb-search>
+      <div class="top-actions">
+        <a routerLink="/home" class="action-link">← Back to dashboard</a>
+        <a
+          *ngIf="(canManage$ | async)"
+          routerLink="/kb/admin"
+          class="action-link admin"
+        >
+          Admin console
+        </a>
+        <app-kb-search></app-kb-search>
+      </div>
     </header>
 
     <div class="content">

--- a/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.scss
@@ -2,11 +2,12 @@
   display: grid;
   grid-template-columns: 320px minmax(0, 1fr);
   min-height: calc(100vh - 80px);
-  background: #eef1ff;
+  background: linear-gradient(135deg, #f4f6fb 0%, #ffffff 85%);
 }
 
 .sidebar-area {
-  border-right: 1px solid rgba(95, 110, 252, 0.12);
+  border-right: 1px solid #e2e7ef;
+  background: transparent;
 }
 
 .main-area {
@@ -20,17 +21,59 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 2rem;
+  gap: 2.5rem;
+  padding: 1.5rem 1.75rem;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 22px 45px rgba(26, 40, 68, 0.08);
 
   .title {
     h1 {
       margin: 0;
       font-size: 2rem;
+      font-weight: 600;
+      color: #1f2a44;
     }
 
     p {
       margin: 0.35rem 0 0;
-      color: #5f6575;
+      color: #6d768a;
+      max-width: 520px;
+    }
+  }
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  app-kb-search {
+    min-width: 260px;
+  }
+}
+
+.action-link {
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1f5fd5;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: #eef3fb;
+  transition: background 0.15s ease, transform 0.12s ease;
+
+  &:hover {
+    background: #dce6f8;
+    transform: translateY(-1px);
+  }
+
+  &.admin {
+    background: #1f5fd5;
+    color: #fff;
+
+    &:hover {
+      background: #174bb0;
     }
   }
 }
@@ -48,5 +91,21 @@
 
   .sidebar-area {
     order: 2;
+  }
+
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.25rem;
+  }
+
+  .top-actions {
+    width: 100%;
+    flex-wrap: wrap;
+
+    app-kb-search {
+      flex: 1;
+      min-width: 200px;
+    }
   }
 }

--- a/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-shell/knowledge-shell.component.ts
@@ -1,17 +1,22 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterOutlet } from '@angular/router';
+import { Component, inject } from '@angular/core';
+import { AsyncPipe, CommonModule } from '@angular/common';
+import { RouterLink, RouterOutlet } from '@angular/router';
+import { map } from 'rxjs';
 import { KbSidebarComponent } from '../kb-sidebar/kb-sidebar.component';
 import { KbSearchComponent } from '../kb-search/kb-search.component';
 import { KbListComponent } from '../kb-list/kb-list.component';
 import { KbArticleComponent } from '../kb-article/kb-article.component';
+import { AuthService } from '../../../auth/auth.service';
+import { PermissionLevel } from '../../../auth/models/permission-level.model';
 
 @Component({
   selector: 'app-knowledge-shell',
   standalone: true, // or declare in a module if you’re using NgModule
   imports: [
     CommonModule,
+    AsyncPipe,
     RouterOutlet,
+    RouterLink,
     KbSidebarComponent,
     KbSearchComponent,
     KbListComponent,
@@ -20,4 +25,12 @@ import { KbArticleComponent } from '../kb-article/kb-article.component';
   templateUrl: './knowledge-shell.component.html',
   styleUrls: ['./knowledge-shell.component.scss'],
 })
-export class KnowledgeShellComponent {}
+export class KnowledgeShellComponent {
+  private readonly auth = inject(AuthService);
+
+  readonly canManage$ = this.auth.currentUser$.pipe(
+    map((user) =>
+      user ? user.permissionLevel <= PermissionLevel.Administrator : false,
+    ),
+  );
+}

--- a/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.html
+++ b/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.html
@@ -1,12 +1,15 @@
 <aside class="sidebar">
   <div class="brand">
-    <h2>Workspace</h2>
-    <p>Organise learning like Google Classroom, but tailored to your crews.</p>
-    <button routerLink="/kb/training" class="cta">📘 Training hub</button>
+    <h2>Knowledge hub</h2>
+    <p>Reference SOPs, project learnings, and onboarding in one organised space.</p>
+    <a routerLink="/kb/training" class="cta">📚 Training library</a>
   </div>
 
-  <section *ngIf="(favourites$ | async)?.length">
-    <h3>Pinned folders</h3>
+  <section *ngIf="(favourites$ | async)?.length" class="pinned">
+    <header class="section-heading">
+      <h3>Pinned folders</h3>
+      <span>Frequent references</span>
+    </header>
     <button
       class="folder-pill"
       *ngFor="let folder of (favourites$ | async)"
@@ -17,31 +20,83 @@
     </button>
   </section>
 
-  <section>
-    <h3>All folders</h3>
+  <section class="folder-section">
+    <header class="section-heading">
+      <h3>All folders</h3>
+      <button
+        type="button"
+        class="text-link"
+        *ngIf="(canManage$ | async)"
+        (click)="toggleFolderForm()"
+      >
+        {{ showFolderForm ? 'Cancel' : 'New folder' }}
+      </button>
+    </header>
+
+    <form
+      class="folder-form"
+      *ngIf="showFolderForm && (canManage$ | async)"
+      [formGroup]="folderForm"
+      (ngSubmit)="createFolder()"
+    >
+      <div class="row">
+        <label>
+          <span>Name</span>
+          <input type="text" formControlName="name" placeholder="e.g. Site handovers" />
+        </label>
+        <label>
+          <span>Icon</span>
+          <input type="text" formControlName="icon" maxlength="2" />
+        </label>
+      </div>
+      <label>
+        <span>Description</span>
+        <textarea
+          formControlName="description"
+          rows="2"
+          placeholder="What belongs in this folder?"
+        ></textarea>
+      </label>
+      <div class="row">
+        <label>
+          <span>Colour</span>
+          <input type="color" formControlName="colour" />
+        </label>
+        <button class="create" type="submit" [disabled]="folderForm.invalid || creatingFolder">
+          {{ creatingFolder ? 'Creating…' : 'Create folder' }}
+        </button>
+      </div>
+      <p class="form-message" *ngIf="creationMessage" [class.error]="creationError">
+        {{ creationMessage }}
+      </p>
+    </form>
+
     <div class="folder-list" *ngIf="(folders$ | async) as folders">
       <article class="folder" *ngFor="let folder of folders" (click)="selectFolder(folder)">
-        <div class="icon" [style.background]="folder.colour || '#5f6efc'">{{ folder.icon || '📁' }}</div>
+        <div class="icon" [style.background]="folder.colour || '#2f3a4c'">{{ folder.icon || '📁' }}</div>
         <div class="copy">
           <strong>{{ folder.name }}</strong>
-          <span>{{ folder.completedCount }}/{{ folder.articleCount }} completed</span>
+          <span>{{ folder.completedCount }}/{{ folder.articleCount }} complete</span>
         </div>
       </article>
     </div>
   </section>
 
-  <section *ngIf="(modules$ | async) as modules">
-    <h3>Training playlists</h3>
+  <section *ngIf="(modules$ | async) as modules" class="modules">
+    <header class="section-heading">
+      <h3>Training playlists</h3>
+      <span>Structured upskilling</span>
+    </header>
     <div class="module" *ngFor="let module of modules">
       <header>
         <span class="colour" [style.background]="module.colour || '#4ac6b7'"></span>
         <div>
           <strong>{{ module.title }}</strong>
-          <small>{{ module.articleIds.length }} lessons • {{ module.quizIds.length }} quizzes</small>
+          <small>{{ module.articleIds.length }} articles • {{ module.quizIds.length }} quizzes</small>
         </div>
       </header>
       <footer>
-        <button class="ghost" [routerLink]="['/kb/training', module.id]">Open module</button>
+        <a class="ghost" [routerLink]="['/kb/training', module.id]">Open module</a>
       </footer>
     </div>
   </section>

--- a/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.scss
+++ b/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.scss
@@ -1,37 +1,49 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-  padding: 2rem 1.5rem;
-  background: linear-gradient(180deg, #f6f7ff 0%, #ffffff 40%);
-  border-right: 1px solid rgba(95, 110, 252, 0.1);
+  gap: 1.5rem;
+  padding: 2rem 1.75rem;
+  background: linear-gradient(180deg, #f8f9fc 0%, #ffffff 60%);
+  border-right: 1px solid #e2e7ef;
   height: 100%;
 
   .brand {
-    background: #3847d0;
-    color: #fff;
+    background: #1f2a44;
+    color: #f6f8ff;
     border-radius: 18px;
-    padding: 1.5rem;
-    box-shadow: 0 20px 40px rgba(56, 71, 208, 0.25);
+    padding: 1.75rem 1.5rem;
+    box-shadow: 0 20px 38px rgba(20, 32, 66, 0.25);
 
     h2 {
       margin: 0;
+      font-size: 1.5rem;
+      letter-spacing: 0.01em;
     }
 
     p {
-      opacity: 0.82;
       margin: 0.75rem 0 1.5rem;
+      color: rgba(239, 242, 255, 0.76);
+      line-height: 1.4;
     }
 
     .cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
       width: 100%;
-      border: none;
-      padding: 0.75rem 1.25rem;
-      border-radius: 14px;
-      background: #fff;
-      color: #3847d0;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      background: #f6f8ff;
+      color: #1f2a44;
       font-weight: 600;
-      cursor: pointer;
+      text-decoration: none;
+      transition: background 0.15s ease, transform 0.15s ease;
+
+      &:hover {
+        background: #e6ecf8;
+        transform: translateY(-1px);
+      }
     }
   }
 
@@ -39,32 +51,145 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+  }
+
+  .section-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
 
     h3 {
       margin: 0;
       font-size: 1rem;
-      color: #4a4f68;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
+      font-weight: 600;
+      color: #1f2a44;
     }
+
+    span {
+      font-size: 0.75rem;
+      color: #6d768a;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }
+  }
+
+  .text-link {
+    border: none;
+    background: transparent;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #1f5fd5;
+    cursor: pointer;
+    padding: 0.25rem 0.35rem;
   }
 
   .folder-pill {
     border: none;
-    background: #fff;
+    background: #ffffff;
     border-radius: 999px;
-    padding: 0.5rem 1rem;
+    padding: 0.45rem 1rem;
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
-    box-shadow: 0 12px 20px rgba(45, 53, 126, 0.12);
+    box-shadow: 0 10px 20px rgba(18, 43, 78, 0.1);
+    color: #1f2a44;
+    font-weight: 500;
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 14px 24px rgba(18, 43, 78, 0.12);
+    }
 
     .dot {
       width: 10px;
       height: 10px;
       border-radius: 50%;
-      background: #5f6efc;
+      background: #1f5fd5;
+    }
+  }
+
+  .folder-form {
+    background: #f1f4f9;
+    border: 1px solid #dbe2ef;
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    .row {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    label {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 140px;
+      gap: 0.35rem;
+      font-size: 0.8rem;
+      color: #435063;
+
+      span {
+        font-weight: 600;
+      }
+
+      input,
+      textarea {
+        border-radius: 8px;
+        border: 1px solid #c8d1e0;
+        padding: 0.55rem 0.65rem;
+        font-size: 0.85rem;
+        font-family: inherit;
+        color: #1f2a44;
+        background: #fff;
+      }
+
+      textarea {
+        resize: vertical;
+        min-height: 64px;
+      }
+
+      input[type='color'] {
+        padding: 0.2rem;
+        height: 42px;
+      }
+    }
+
+    .create {
+      align-self: flex-end;
+      border: none;
+      border-radius: 10px;
+      padding: 0.6rem 1.25rem;
+      background: #1f5fd5;
+      color: #fff;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s ease;
+
+      &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      &:not(:disabled):hover {
+        background: #174bb0;
+      }
+    }
+
+    .form-message {
+      margin: 0;
+      font-size: 0.8rem;
+      color: #1f2a44;
+
+      &.error {
+        color: #c73737;
+      }
     }
   }
 
@@ -76,11 +201,19 @@
     .folder {
       display: flex;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.9rem;
       padding: 0.75rem 1rem;
       border-radius: 14px;
-      background: rgba(95, 110, 252, 0.08);
+      border: 1px solid transparent;
+      background: #f5f7fb;
       cursor: pointer;
+      transition: border 0.15s ease, background 0.15s ease, transform 0.12s ease;
+
+      &:hover {
+        background: #eef3fb;
+        border-color: #d5def0;
+        transform: translateY(-1px);
+      }
 
       .icon {
         width: 40px;
@@ -89,6 +222,7 @@
         display: grid;
         place-items: center;
         color: #fff;
+        font-size: 1.25rem;
       }
 
       .copy {
@@ -98,43 +232,50 @@
 
         strong {
           margin: 0;
+          color: #1f2a44;
         }
 
         span {
           font-size: 0.8rem;
-          color: #6f768a;
+          color: #6d768a;
         }
       }
     }
   }
 
+  .modules {
+    gap: 1.25rem;
+  }
+
   .module {
-    background: #fff;
-    border-radius: 18px;
+    background: #ffffff;
+    border: 1px solid #e1e7f1;
+    border-radius: 16px;
     padding: 1rem 1.25rem;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    box-shadow: 0 18px 36px rgba(45, 53, 126, 0.12);
+    box-shadow: 0 14px 30px rgba(26, 48, 79, 0.08);
 
     header {
       display: flex;
-      gap: 0.75rem;
+      gap: 0.85rem;
       align-items: center;
 
       .colour {
-        width: 12px;
-        height: 40px;
+        width: 10px;
+        height: 42px;
         border-radius: 6px;
         background: #4ac6b7;
       }
 
       strong {
         display: block;
+        color: #1f2a44;
       }
 
       small {
-        color: #6f768a;
+        color: #6d768a;
       }
     }
 
@@ -143,13 +284,19 @@
       justify-content: flex-end;
 
       .ghost {
-        border: none;
-        padding: 0.5rem 1rem;
+        display: inline-flex;
+        align-items: center;
         border-radius: 999px;
-        background: rgba(95, 110, 252, 0.12);
-        cursor: pointer;
-        color: #3847d0;
+        padding: 0.45rem 1.1rem;
+        background: #eef3fb;
+        color: #1f5fd5;
         font-weight: 600;
+        text-decoration: none;
+        transition: background 0.15s ease;
+
+        &:hover {
+          background: #dce6f8;
+        }
       }
     }
   }

--- a/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.ts
+++ b/src/app/knowledge-base/knowledge-component/kb-sidebar/kb-sidebar.component.ts
@@ -1,23 +1,105 @@
 import { AsyncPipe, CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
+import {
+  FormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { map } from 'rxjs';
 import { KbService } from '../kb.service';
 import { KnowledgeFolder } from '../models/folder.model';
+import { AuthService } from '../../../auth/auth.service';
+import { PermissionLevel } from '../../../auth/models/permission-level.model';
 
 @Component({
   selector: 'app-kb-sidebar',
   templateUrl: './kb-sidebar.component.html',
   styleUrls: ['./kb-sidebar.component.scss'],
-  imports: [RouterModule, CommonModule, AsyncPipe],
+  imports: [RouterModule, CommonModule, AsyncPipe, ReactiveFormsModule],
 })
 export class KbSidebarComponent {
   private readonly kb = inject(KbService);
+  private readonly auth = inject(AuthService);
+  private readonly fb = inject(FormBuilder);
 
   readonly folders$ = this.kb.listFolders();
   readonly favourites$ = this.kb.favouriteFolders();
   readonly modules$ = this.kb.listTrainingModules();
+  readonly canManage$ = this.auth.currentUser$.pipe(
+    map((user) =>
+      user ? user.permissionLevel <= PermissionLevel.Administrator : false,
+    ),
+  );
+
+  readonly folderForm = this.fb.group({
+    name: ['', [Validators.required, Validators.minLength(2)]],
+    description: [''],
+    colour: ['#2f3a4c'],
+    icon: ['📁'],
+  });
+
+  showFolderForm = false;
+  creatingFolder = false;
+  creationMessage = '';
+  creationError = false;
 
   selectFolder(folder: KnowledgeFolder) {
     this.kb.updateFilters({ folderId: folder.id });
+  }
+
+  toggleFolderForm() {
+    this.showFolderForm = !this.showFolderForm;
+    this.creationMessage = '';
+    this.creationError = false;
+    if (this.showFolderForm) {
+      this.folderForm.reset({
+        name: '',
+        description: '',
+        colour: '#2f3a4c',
+        icon: '📁',
+      });
+    }
+  }
+
+  createFolder() {
+    if (this.folderForm.invalid || this.creatingFolder) {
+      this.folderForm.markAllAsTouched();
+      return;
+    }
+
+    this.creatingFolder = true;
+    this.creationMessage = '';
+    this.creationError = false;
+
+    const value = this.folderForm.value;
+
+    this.kb
+      .createFolder({
+        name: value.name ?? '',
+        description: value.description ?? undefined,
+        colour: value.colour ?? undefined,
+        icon: value.icon ?? undefined,
+      })
+      .subscribe({
+        next: () => {
+          this.creatingFolder = false;
+          this.creationMessage = 'Folder created successfully.';
+          this.creationError = false;
+          this.folderForm.reset({
+            name: '',
+            description: '',
+            colour: '#2f3a4c',
+            icon: '📁',
+          });
+          this.showFolderForm = false;
+        },
+        error: (error) => {
+          console.error('Failed to create knowledge folder', error);
+          this.creatingFolder = false;
+          this.creationMessage = 'We could not create the folder. Please try again.';
+          this.creationError = true;
+        },
+      });
   }
 }

--- a/src/app/shared/supabase-service/db_functions.service.ts
+++ b/src/app/shared/supabase-service/db_functions.service.ts
@@ -224,6 +224,20 @@ export class dbFunctionsService {
     return data.folders as KnowledgeFolder[];
   }
 
+  async createKnowledgeFolder(
+    folder: Partial<KnowledgeFolder> & { name: string },
+  ): Promise<KnowledgeFolder> {
+    const { data, error } = await this.supabaseService.client.functions.invoke(
+      'knowledgebase-hub',
+      {
+        headers: this.orgHeaders({ 'x-query-type': 'upsert-folder' }),
+        body: { folder },
+      },
+    );
+    if (error) throw error;
+    return data.folder as KnowledgeFolder;
+  }
+
   async getTrainingModules(): Promise<TrainingModule[]> {
     const { data, error } = await this.supabaseService.client.functions.invoke(
       'knowledgebase-hub',


### PR DESCRIPTION
## Summary
- add Supabase helper and service wiring for creating knowledge folders and expose creation form in the sidebar for admins
- refresh the knowledge shell header with professional copy, dashboard navigation, and an admin console shortcut
- update knowledge list visuals to align with the new workspace-focused aesthetic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff4e987d4c8323bfc23bf2510fdb6c