### PR TITLE
Add Stage Timer tools experience with presenter view

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -121,6 +121,13 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'tools',
+    loadChildren: () =>
+      import('./tools/tools.routes').then((m) => m.ToolsRoutes),
+    title: 'Tools | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
     path: '**',
     component: NotFoundComponent,
     title: 'Page not found | Cue RMS',

--- a/src/app/shared/main-navigation-component/main-navigation-component.html
+++ b/src/app/shared/main-navigation-component/main-navigation-component.html
@@ -16,10 +16,25 @@
 
   <ul class="nav__links">
     @for (item of navItems; track item.label) {
-      <li>
-        <a [routerLink]="item.path" routerLinkActive="active">{{
-          item.label
-        }}</a>
+      <li [class.nav__item--group]="isGroup(item)">
+        @if (isGroup(item)) {
+          <div class="nav__group">
+            <div class="nav__group-label">{{ item.label }}</div>
+            <ul class="nav__group-links">
+              @for (child of item.children; track child.label) {
+                <li>
+                  <a [routerLink]="child.path" routerLinkActive="active">
+                    {{ child.label }}
+                  </a>
+                </li>
+              }
+            </ul>
+          </div>
+        } @else {
+          <a [routerLink]="item.path" routerLinkActive="active">{{
+            item.label
+          }}</a>
+        }
       </li>
     }
   </ul>

--- a/src/app/shared/main-navigation-component/main-navigation-component.scss
+++ b/src/app/shared/main-navigation-component/main-navigation-component.scss
@@ -18,6 +18,34 @@ nav {
   gap: 0.25rem;
 }
 
+.nav__item--group {
+  padding-bottom: 0.5rem;
+}
+
+.nav__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.nav__group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba($main-text-color, 0.7);
+  padding: 0.25rem 0.8rem;
+}
+
+.nav__group-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
 .nav__links li,
 .nav__actions--sub-nav li {
   width: 100%;

--- a/src/app/shared/main-navigation-component/main-navigation-component.ts
+++ b/src/app/shared/main-navigation-component/main-navigation-component.ts
@@ -6,11 +6,19 @@ import { AuthService } from '../../auth/auth.service';
 import { dbFunctionsService } from '../supabase-service/db_functions.service';
 import { OrgBrandingService } from '../org-branding/org-branding.service';
 
-type NavigationItem = {
+type NavigationLink = {
   label: string;
   path: string;
   available?: boolean;
 };
+
+type NavigationGroup = {
+  label: string;
+  children: NavigationLink[];
+  available?: boolean;
+};
+
+type NavigationItem = NavigationLink | NavigationGroup;
 
 @Component({
   selector: 'main-navigation-component',
@@ -49,7 +57,7 @@ export class MainNavigationComponent implements OnInit {
       );
       const items = Array.isArray(response) ? response : [];
 
-      this.navItems = items
+      const flattened = items
         .filter((item) => item && item.available !== false)
         .map((item) => ({
           label: item.label ?? '',
@@ -57,9 +65,11 @@ export class MainNavigationComponent implements OnInit {
           available: item.available,
         }))
         .filter((item) => item.label && item.path);
+
+      this.navItems = [...flattened, this.createToolsNavigation()];
     } catch (error) {
       console.error('Failed to load navigation items', error);
-      this.navItems = [];
+      this.navItems = [this.createToolsNavigation()];
     }
   }
 
@@ -80,5 +90,21 @@ export class MainNavigationComponent implements OnInit {
       this.orgName = 'Company Name';
       this.orgLogoUrl = null;
     }
+  }
+
+  protected isGroup(item: NavigationItem): item is NavigationGroup {
+    return 'children' in item && Array.isArray(item.children);
+  }
+
+  private createToolsNavigation(): NavigationGroup {
+    return {
+      label: 'Tools',
+      children: [
+        {
+          label: 'Stage Timer',
+          path: '/tools/stage-timer',
+        },
+      ],
+    };
   }
 }

--- a/src/app/tools/stage-timer-dashboard/stage-timer-dashboard.component.html
+++ b/src/app/tools/stage-timer-dashboard/stage-timer-dashboard.component.html
@@ -1,0 +1,215 @@
+<section class="stage-timer">
+  <header class="stage-timer__header">
+    <div class="stage-timer__heading">
+      <h1>Stage Timer</h1>
+      <p>Monitor, create, and control timers across your master scene.</p>
+    </div>
+    <div class="stage-timer__actions">
+      <button type="button" class="btn btn--primary" (click)="toggleCreateForm()">
+        {{ showCreateForm ? 'Close form' : 'New timer' }}
+      </button>
+      <a
+        class="btn btn--ghost"
+        href=""
+        (click)="openPresenterAccess($event)"
+        title="Open presenter access"
+        >Presenter access</a
+      >
+    </div>
+  </header>
+
+  <form
+    class="stage-timer__form"
+    *ngIf="showCreateForm"
+    (ngSubmit)="createTimer($event)"
+  >
+    <div class="form-grid">
+      <label>
+        <span>Timer name</span>
+        <input
+          type="text"
+          name="timerName"
+          [(ngModel)]="newTimerName"
+          placeholder="Backstage countdown"
+        />
+      </label>
+      <label>
+        <span>Minutes</span>
+        <input
+          type="number"
+          min="0"
+          name="timerMinutes"
+          [(ngModel)]="newTimerMinutes"
+        />
+      </label>
+      <label>
+        <span>Seconds</span>
+        <input
+          type="number"
+          min="0"
+          max="59"
+          name="timerSeconds"
+          [(ngModel)]="newTimerSeconds"
+        />
+      </label>
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="btn btn--primary">Create timer</button>
+      <button type="button" class="btn btn--ghost" (click)="toggleCreateForm()">
+        Cancel
+      </button>
+    </div>
+  </form>
+
+  <div class="stage-timer__content" *ngIf="timers$ | async as timers">
+    <div class="stage-timer__list" [class.stage-timer__list--empty]="!timers.length">
+      <article
+        class="timer-card"
+        *ngFor="let timer of timers; trackBy: trackByTimer"
+        [class.timer-card--selected]="isSelected(timer)"
+        (click)="selectTimer(timer)"
+      >
+        <header class="timer-card__header">
+          <h3>{{ timer.name }}</h3>
+          <span class="timer-card__status" [ngClass]="'status--' + timer.status">
+            {{ timerStatusBadge(timer) }}
+          </span>
+        </header>
+        <div class="timer-card__countdown">{{ formatTime(timer.remainingSeconds) }}</div>
+        <div class="timer-card__meta">
+          <div class="timer-card__code">Code · <strong>{{ timer.code }}</strong></div>
+          <div class="timer-card__scene">Scene · Master</div>
+        </div>
+        <div class="timer-card__progress">
+          <div
+            class="timer-card__progress-bar"
+            [style.width.%]="timerProgress(timer)"
+          ></div>
+        </div>
+        <footer class="timer-card__footer">
+          <button type="button" class="btn btn--secondary" (click)="toggleTimer(timer, $event)">
+            {{ timer.status === 'running' ? 'Pause' : timer.status === 'completed' ? 'Restart' : 'Start' }}
+          </button>
+          <button type="button" class="btn" (click)="resetTimer(timer, $event)">Reset</button>
+          <button
+            type="button"
+            class="btn"
+            title="Open presenter view"
+            (click)="openPresenter(timer, $event)"
+          >
+            Presenter
+          </button>
+          <button
+            type="button"
+            class="btn btn--danger"
+            title="Delete timer"
+            (click)="deleteTimer(timer, $event)"
+          >
+            Delete
+          </button>
+        </footer>
+        <div class="timer-card__urgent" *ngIf="timer.urgentNote && !timer.urgentNote.acknowledgedAt">
+          <span>Urgent note active</span>
+        </div>
+      </article>
+      <p class="stage-timer__empty" *ngIf="!timers.length">
+        No timers yet. Use the <strong>New timer</strong> button to create one.
+      </p>
+    </div>
+
+    <aside class="stage-timer__detail" *ngIf="selectedTimerId as selectedId">
+      <ng-container *ngIf="timers.find((timer) => timer.id === selectedId) as selected">
+        <header class="detail__header">
+          <div>
+            <h2>{{ selected.name }}</h2>
+            <p>Code · <strong>{{ selected.code }}</strong></p>
+          </div>
+          <span class="detail__status" [ngClass]="'status--' + selected.status">
+            {{ timerStatusBadge(selected) }}
+          </span>
+        </header>
+
+        <div class="detail__countdown">{{ formatTime(selected.remainingSeconds) }}</div>
+        <div class="detail__progress">
+          <div class="detail__progress-track">
+            <div
+              class="detail__progress-fill"
+              [style.width.%]="timerProgress(selected)"
+            ></div>
+          </div>
+          <div class="detail__meta">
+            <span>Duration · {{ formatTime(selected.durationSeconds) }}</span>
+            <span>Remaining · {{ formatTime(selected.remainingSeconds) }}</span>
+          </div>
+        </div>
+
+        <div class="detail__controls">
+          <button type="button" class="btn btn--primary" (click)="toggleTimer(selected, $event)">
+            {{ selected.status === 'running' ? 'Pause timer' : 'Start timer' }}
+          </button>
+          <button type="button" class="btn" (click)="resetTimer(selected, $event)">
+            Reset timer
+          </button>
+          <button type="button" class="btn" (click)="openPresenter(selected, $event)">
+            Open presenter
+          </button>
+        </div>
+
+        <section class="detail__section">
+          <header class="detail__section-header">
+            <h3>Notes</h3>
+            <p>Keep everyone aligned with running notes.</p>
+          </header>
+          <ul class="notes" *ngIf="notesFor(selected) as notes">
+            <li *ngFor="let note of notes">
+              <span class="notes__time">{{ note.createdAt | date: 'shortTime' }}</span>
+              <span class="notes__body">{{ note.body }}</span>
+            </li>
+            <li *ngIf="!notes.length" class="notes__empty">No notes yet.</li>
+          </ul>
+          <form class="notes__form" (ngSubmit)="addNote(selected)">
+            <textarea
+              name="noteDraft"
+              [(ngModel)]="noteDraft"
+              rows="3"
+              placeholder="Add a note for this timer..."
+            ></textarea>
+            <button type="submit" class="btn btn--secondary">Add note</button>
+          </form>
+        </section>
+
+        <section class="detail__section detail__section--urgent">
+          <header class="detail__section-header">
+            <h3>Urgent note</h3>
+            <p>Send high-priority alerts to the presenter instantly.</p>
+          </header>
+          <ng-container *ngIf="urgentNoteFor(selected) as urgent; else urgentForm">
+            <div class="urgent-note" [class.urgent-note--acknowledged]="urgent.acknowledgedAt">
+              <div class="urgent-note__message">{{ urgent.body }}</div>
+              <div class="urgent-note__meta">
+                Sent {{ urgent.createdAt | date: 'shortTime' }}
+                <span *ngIf="urgent.acknowledgedAt">
+                  · Acknowledged {{ urgent.acknowledgedAt | date: 'shortTime' }}
+                </span>
+              </div>
+              <button type="button" class="btn btn--ghost" (click)="clearUrgent(selected)">
+                Clear urgent note
+              </button>
+            </div>
+          </ng-container>
+          <ng-template #urgentForm>
+            <form class="urgent-form" (ngSubmit)="addUrgentNote(selected)">
+              <textarea
+                name="urgentDraft"
+                [(ngModel)]="urgentNoteDraft"
+                rows="3"
+                placeholder="Alert the presenter to an urgent change..."
+              ></textarea>
+              <button type="submit" class="btn btn--danger">Send urgent note</button>
+            </form>
+          </ng-template>
+        </section>
+      </ng-container>
+    </aside>
+  </div>
+</section>

--- a/src/app/tools/stage-timer-dashboard/stage-timer-dashboard.component.scss
+++ b/src/app/tools/stage-timer-dashboard/stage-timer-dashboard.component.scss
@@ -1,0 +1,444 @@
+@use '../../../style/colors.scss' as *;
+
+:host {
+  display: block;
+  height: 100%;
+}
+
+.stage-timer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  background-color: rgba($main-light-color, 0.92);
+  min-height: 100%;
+}
+
+.stage-timer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.stage-timer__heading h1 {
+  font-size: 1.8rem;
+  margin: 0;
+}
+
+.stage-timer__heading p {
+  margin: 0.25rem 0 0;
+  color: rgba($main-text-color, 0.7);
+}
+
+.stage-timer__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.btn {
+  border-radius: $minor-border-radius;
+  border: $main-border;
+  background-color: $main-light-color;
+  color: $main-text-color;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: $quick-transition;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+}
+
+.btn:hover {
+  border-color: rgba($accent-color, 0.45);
+  color: $accent-color;
+}
+
+.btn--primary {
+  background-color: $accent-color;
+  border-color: $accent-color;
+  color: #fff;
+}
+
+.btn--primary:hover {
+  background-color: darken($accent-color, 5%);
+  border-color: darken($accent-color, 5%);
+  color: #fff;
+}
+
+.btn--secondary {
+  background-color: rgba($accent-color, 0.12);
+  border-color: rgba($accent-color, 0.32);
+  color: $accent-color;
+}
+
+.btn--danger {
+  background-color: rgba(#d93025, 0.12);
+  border-color: rgba(#d93025, 0.36);
+  color: #d93025;
+}
+
+.btn--danger:hover {
+  background-color: rgba(#d93025, 0.22);
+}
+
+.btn--ghost {
+  background-color: transparent;
+  border-color: transparent;
+  color: $accent-color;
+}
+
+.btn--ghost:hover {
+  background-color: rgba($accent-color, 0.12);
+}
+
+.stage-timer__form {
+  background-color: $main-light-color;
+  border-radius: $major-border-radius;
+  padding: 1.25rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.form-grid input,
+.notes__form textarea,
+.urgent-form textarea {
+  border-radius: $minor-border-radius;
+  border: $main-border;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  background-color: #fff;
+  transition: $quick-transition;
+}
+
+.form-grid input:focus,
+.notes__form textarea:focus,
+.urgent-form textarea:focus {
+  outline: none;
+  border-color: rgba($accent-color, 0.7);
+  box-shadow: 0 0 0 4px rgba($accent-color, 0.14);
+}
+
+.form-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.stage-timer__content {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  flex: 1 1 auto;
+}
+
+.stage-timer__list {
+  flex: 1 1 60%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.stage-timer__list--empty {
+  display: flex;
+  flex-direction: column;
+}
+
+.stage-timer__empty {
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: $major-border-radius;
+  background-color: rgba($accent-color, 0.08);
+  color: rgba($main-text-color, 0.75);
+  text-align: center;
+}
+
+.timer-card {
+  background-color: $main-light-color;
+  border-radius: $major-border-radius;
+  border: 2px solid transparent;
+  padding: 1.25rem;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  cursor: pointer;
+  position: relative;
+  transition: transform $quick-transition, box-shadow $quick-transition;
+}
+
+.timer-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.12);
+}
+
+.timer-card--selected {
+  border-color: rgba($accent-color, 0.4);
+  box-shadow: 0 18px 46px rgba($accent-color, 0.18);
+}
+
+.timer-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.timer-card__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.timer-card__status {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background-color: rgba($main-text-color, 0.1);
+  color: $main-text-color;
+}
+
+.status--running {
+  background-color: rgba(#00a76f, 0.16);
+  color: #007350;
+}
+
+.status--paused {
+  background-color: rgba(#fbbc05, 0.18);
+  color: #a96a00;
+}
+
+.status--completed {
+  background-color: rgba(#5f6368, 0.2);
+  color: #3c4043;
+}
+
+.timer-card__countdown {
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.timer-card__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba($main-text-color, 0.65);
+}
+
+.timer-card__progress {
+  height: 6px;
+  background-color: rgba($main-text-color, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.timer-card__progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, $accent-color, lighten($accent-color, 10%));
+  transition: width 0.4s ease;
+}
+
+.timer-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.timer-card__urgent {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background-color: rgba(#d93025, 0.18);
+  color: #d93025;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.stage-timer__detail {
+  flex: 1 1 40%;
+  background-color: $main-light-color;
+  border-radius: $major-border-radius;
+  padding: 1.75rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.12);
+  position: sticky;
+  top: 2rem;
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.detail__header h2 {
+  margin: 0;
+}
+
+.detail__header p {
+  margin: 0.25rem 0 0;
+  color: rgba($main-text-color, 0.65);
+}
+
+.detail__status {
+  @extend .timer-card__status;
+}
+
+.detail__countdown {
+  font-size: 3.4rem;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.06em;
+}
+
+.detail__progress-track {
+  height: 10px;
+  background-color: rgba($main-text-color, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.detail__progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, $accent-color, lighten($accent-color, 15%));
+  transition: width 0.4s ease;
+}
+
+.detail__meta {
+  display: flex;
+  justify-content: space-between;
+  color: rgba($main-text-color, 0.6);
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.detail__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.detail__section-header h3 {
+  margin: 0;
+}
+
+.detail__section-header p {
+  margin: 0.2rem 0 0;
+  color: rgba($main-text-color, 0.6);
+}
+
+.notes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.notes__time {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba($main-text-color, 0.55);
+}
+
+.notes__body {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.notes__empty {
+  font-size: 0.9rem;
+  color: rgba($main-text-color, 0.5);
+}
+
+.notes__form,
+.urgent-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.urgent-form textarea {
+  background: rgba(#d93025, 0.04);
+  border-color: rgba(#d93025, 0.4);
+}
+
+.detail__section--urgent {
+  border-top: 1px solid rgba($main-text-color, 0.1);
+  padding-top: 1rem;
+}
+
+.urgent-note {
+  border-radius: $major-border-radius;
+  border: 1px solid rgba(#d93025, 0.4);
+  background: rgba(#d93025, 0.08);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.urgent-note__message {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.urgent-note__meta {
+  font-size: 0.8rem;
+  color: rgba(#d93025, 0.8);
+}
+
+.urgent-note--acknowledged {
+  border-color: rgba(#007350, 0.35);
+  background: rgba(#00a76f, 0.08);
+}
+
+.urgent-note--acknowledged .urgent-note__meta {
+  color: #007350;
+}
+
+@media (max-width: 1080px) {
+  .stage-timer__content {
+    flex-direction: column;
+  }
+
+  .stage-timer__detail {
+    position: relative;
+    top: 0;
+    width: 100%;
+  }
+}

--- a/src/app/tools/stage-timer-dashboard/stage-timer-dashboard.component.ts
+++ b/src/app/tools/stage-timer-dashboard/stage-timer-dashboard.component.ts
@@ -1,0 +1,183 @@
+import { AsyncPipe, DatePipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { Subscription } from 'rxjs';
+import {
+  CreateStageTimerPayload,
+  StageTimer,
+  StageTimerNote,
+  StageTimerUrgentNote,
+} from '../stage-timer.models';
+import { StageTimerService } from '../stage-timer.service';
+
+@Component({
+  selector: 'stage-timer-dashboard',
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    DatePipe,
+    FormsModule,
+    NgClass,
+    NgFor,
+    NgIf,
+    RouterLink,
+  ],
+  templateUrl: './stage-timer-dashboard.component.html',
+  styleUrl: './stage-timer-dashboard.component.scss',
+})
+export class StageTimerDashboardComponent implements OnInit, OnDestroy {
+  private readonly stageTimerService = inject(StageTimerService);
+  private readonly router = inject(Router);
+  private subscription?: Subscription;
+
+  protected timers$ = this.stageTimerService.timers$;
+  protected selectedTimerId: string | null = null;
+  protected showCreateForm = false;
+  protected newTimerName = '';
+  protected newTimerMinutes = 5;
+  protected newTimerSeconds = 0;
+  protected noteDraft = '';
+  protected urgentNoteDraft = '';
+
+  async ngOnInit(): Promise<void> {
+    await this.stageTimerService.loadTimers();
+    this.subscription = this.timers$.subscribe((timers) => {
+      if (!timers.length) {
+        this.selectedTimerId = null;
+        return;
+      }
+
+      if (this.selectedTimerId) {
+        const stillExists = timers.some(
+          (timer) => timer.id === this.selectedTimerId,
+        );
+        if (stillExists) return;
+      }
+
+      this.selectedTimerId = timers[0]?.id ?? null;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
+  protected async createTimer(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    const payload: CreateStageTimerPayload = {
+      name: this.newTimerName,
+      durationMinutes: this.newTimerMinutes,
+      durationSeconds: this.newTimerSeconds,
+      sceneId: 'master',
+    };
+    const timer = await this.stageTimerService.createTimer(payload);
+    this.selectedTimerId = timer.id;
+    this.showCreateForm = false;
+    this.newTimerName = '';
+    this.newTimerMinutes = 5;
+    this.newTimerSeconds = 0;
+  }
+
+  protected selectTimer(timer: StageTimer): void {
+    this.selectedTimerId = timer.id;
+    this.noteDraft = '';
+    this.urgentNoteDraft = '';
+  }
+
+  protected toggleTimer(timer: StageTimer, event: Event): void {
+    event.stopPropagation();
+    if (timer.status === 'running') {
+      void this.stageTimerService.pauseTimer(timer.id);
+    } else if (timer.status === 'completed') {
+      void this.stageTimerService.resetTimer(timer.id);
+      void this.stageTimerService.startTimer(timer.id);
+    } else {
+      void this.stageTimerService.startTimer(timer.id);
+    }
+  }
+
+  protected resetTimer(timer: StageTimer, event: Event): void {
+    event.stopPropagation();
+    void this.stageTimerService.resetTimer(timer.id);
+  }
+
+  protected deleteTimer(timer: StageTimer, event: Event): void {
+    event.stopPropagation();
+    void this.stageTimerService.deleteTimer(timer.id);
+  }
+
+  protected async addNote(timer: StageTimer): Promise<void> {
+    const draft = this.noteDraft.trim();
+    if (!draft) return;
+    await this.stageTimerService.addNote(timer.id, draft);
+    this.noteDraft = '';
+  }
+
+  protected async addUrgentNote(timer: StageTimer): Promise<void> {
+    const draft = this.urgentNoteDraft.trim();
+    if (!draft) return;
+    await this.stageTimerService.addUrgentNote(timer.id, draft);
+    this.urgentNoteDraft = '';
+  }
+
+  protected async clearUrgent(timer: StageTimer): Promise<void> {
+    await this.stageTimerService.clearUrgentNote(timer.id);
+  }
+
+  protected async openPresenter(timer: StageTimer, event: Event): Promise<void> {
+    event.stopPropagation();
+    await this.router.navigate(['/tools', 'stage-timer', 'presenter', timer.code]);
+  }
+
+  protected async openPresenterAccess(event: Event): Promise<void> {
+    event.preventDefault();
+    await this.router.navigate(['/tools', 'stage-timer', 'presenter']);
+  }
+
+  protected formatTime(totalSeconds: number): string {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+    return `${this.pad(minutes)}:${this.pad(seconds)}`;
+  }
+
+  protected timerStatusBadge(timer: StageTimer): string {
+    const status = timer.status;
+    if (status === 'running') return 'Running';
+    if (status === 'paused') return 'Paused';
+    if (status === 'completed') return 'Completed';
+    return 'Idle';
+  }
+
+  protected timerProgress(timer: StageTimer): number {
+    if (!timer.durationSeconds) return 0;
+    const elapsed = timer.durationSeconds - timer.remainingSeconds;
+    return Math.min(100, Math.max(0, (elapsed / timer.durationSeconds) * 100));
+  }
+
+  protected isSelected(timer: StageTimer): boolean {
+    return timer.id === this.selectedTimerId;
+  }
+
+  protected trackByTimer(_: number, timer: StageTimer): string {
+    return timer.id;
+  }
+
+  protected notesFor(timer: StageTimer): StageTimerNote[] {
+    return [...timer.notes].sort((a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+  }
+
+  protected urgentNoteFor(timer: StageTimer): StageTimerUrgentNote | null {
+    return timer.urgentNote ?? null;
+  }
+
+  protected toggleCreateForm(): void {
+    this.showCreateForm = !this.showCreateForm;
+  }
+
+  private pad(value: number): string {
+    return value.toString().padStart(2, '0');
+  }
+}

--- a/src/app/tools/stage-timer-presenter-access/stage-timer-presenter-access.component.html
+++ b/src/app/tools/stage-timer-presenter-access/stage-timer-presenter-access.component.html
@@ -1,0 +1,47 @@
+<section class="presenter-access">
+  <div class="presenter-access__card">
+    <header class="presenter-access__header">
+      <h1>Presenter access</h1>
+      <p>Join an active stage timer by entering the unique presenter code.</p>
+    </header>
+
+    <form class="presenter-access__form" (ngSubmit)="submit($event)">
+      <label>
+        <span>Timer code</span>
+        <input
+          type="text"
+          name="codeInput"
+          [(ngModel)]="codeInput"
+          maxlength="8"
+          placeholder="e.g. ABC12"
+          autocomplete="off"
+          autocapitalize="characters"
+        />
+      </label>
+      <button type="submit" class="btn btn--primary">Open presenter view</button>
+    </form>
+    <p class="presenter-access__error" *ngIf="errorMessage">{{ errorMessage }}</p>
+
+    <section class="presenter-access__active" *ngIf="timers$ | async as timers">
+      <header>
+        <h2>Active timers</h2>
+        <p>Tap a timer below to jump straight into its presenter view.</p>
+      </header>
+      <ul>
+        <li *ngFor="let timer of timers; trackBy: trackByTimer">
+          <div class="timer-title">
+            <strong>{{ timer.name }}</strong>
+            <span>{{ timer.status | titlecase }}</span>
+          </div>
+          <div class="timer-code">Code · {{ timer.code }}</div>
+          <button type="button" class="btn" (click)="openTimer(timer)">
+            Open presenter
+          </button>
+        </li>
+        <li *ngIf="!timers.length" class="presenter-access__empty">
+          No active timers. <a (click)="goToDashboard()">Create one now.</a>
+        </li>
+      </ul>
+    </section>
+  </div>
+</section>

--- a/src/app/tools/stage-timer-presenter-access/stage-timer-presenter-access.component.scss
+++ b/src/app/tools/stage-timer-presenter-access/stage-timer-presenter-access.component.scss
@@ -1,0 +1,184 @@
+@use '../../../style/colors.scss' as *;
+
+:host {
+  display: block;
+  height: 100%;
+}
+
+.presenter-access {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at top left, rgba($accent-color, 0.12), transparent);
+  min-height: 100%;
+}
+
+.presenter-access__card {
+  width: min(720px, 100%);
+  background-color: $main-light-color;
+  border-radius: $major-border-radius;
+  padding: 2.5rem;
+  box-shadow: 0 18px 46px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.presenter-access__header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.presenter-access__header p {
+  margin: 0.5rem 0 0;
+  color: rgba($main-text-color, 0.65);
+  max-width: 480px;
+}
+
+.presenter-access__form {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.presenter-access__form label {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.presenter-access__form input {
+  border-radius: $minor-border-radius;
+  border: $main-border;
+  padding: 0.75rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.presenter-access__form input:focus {
+  outline: none;
+  border-color: rgba($accent-color, 0.6);
+  box-shadow: 0 0 0 4px rgba($accent-color, 0.18);
+}
+
+.btn {
+  border-radius: $minor-border-radius;
+  border: $main-border;
+  background-color: rgba($accent-color, 0.1);
+  color: $accent-color;
+  padding: 0.7rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: $quick-transition;
+  text-decoration: none;
+}
+
+.btn:hover {
+  border-color: rgba($accent-color, 0.45);
+  background-color: rgba($accent-color, 0.16);
+}
+
+.btn--primary {
+  background-color: $accent-color;
+  color: #fff;
+  border-color: $accent-color;
+}
+
+.btn--primary:hover {
+  background-color: darken($accent-color, 5%);
+  border-color: darken($accent-color, 5%);
+}
+
+.presenter-access__error {
+  margin: 0;
+  color: #d93025;
+  font-weight: 600;
+}
+
+.presenter-access__active header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.presenter-access__active h2 {
+  margin: 0;
+}
+
+.presenter-access__active p {
+  margin: 0;
+  color: rgba($main-text-color, 0.6);
+}
+
+.presenter-access__active ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.presenter-access__active li {
+  border: 1px solid rgba($main-text-color, 0.12);
+  border-radius: $major-border-radius;
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  background-color: rgba($main-light-color, 0.9);
+}
+
+.presenter-access__active li button {
+  justify-self: end;
+}
+
+.timer-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.timer-title span {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba($main-text-color, 0.6);
+}
+
+.timer-code {
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: rgba($main-text-color, 0.7);
+}
+
+.presenter-access__empty {
+  text-align: center;
+  color: rgba($main-text-color, 0.6);
+}
+
+.presenter-access__empty a {
+  color: $accent-color;
+  cursor: pointer;
+}
+
+@media (max-width: 720px) {
+  .presenter-access__form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .presenter-access__active li {
+    grid-template-columns: 1fr;
+  }
+
+  .presenter-access__active li button {
+    justify-self: stretch;
+  }
+}

--- a/src/app/tools/stage-timer-presenter-access/stage-timer-presenter-access.component.ts
+++ b/src/app/tools/stage-timer-presenter-access/stage-timer-presenter-access.component.ts
@@ -1,0 +1,56 @@
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { StageTimer } from '../stage-timer.models';
+import { StageTimerService } from '../stage-timer.service';
+
+@Component({
+  selector: 'stage-timer-presenter-access',
+  standalone: true,
+  imports: [AsyncPipe, FormsModule, NgFor, NgIf],
+  templateUrl: './stage-timer-presenter-access.component.html',
+  styleUrl: './stage-timer-presenter-access.component.scss',
+})
+export class StageTimerPresenterAccessComponent implements OnInit {
+  private readonly stageTimerService = inject(StageTimerService);
+  private readonly router = inject(Router);
+
+  protected timers$ = this.stageTimerService.timers$;
+  protected codeInput = '';
+  protected errorMessage = '';
+
+  async ngOnInit(): Promise<void> {
+    await this.stageTimerService.loadTimers();
+  }
+
+  protected async submit(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    const code = this.codeInput.trim().toUpperCase();
+    if (!code) {
+      this.errorMessage = 'Enter a timer code to open the presenter view.';
+      return;
+    }
+
+    const timer = this.stageTimerService.getTimerByCode(code);
+    if (!timer) {
+      this.errorMessage = 'No timer found for that code. Check the code and try again.';
+      return;
+    }
+
+    this.errorMessage = '';
+    await this.router.navigate(['/tools', 'stage-timer', 'presenter', timer.code]);
+  }
+
+  protected async goToDashboard(): Promise<void> {
+    await this.router.navigate(['/tools', 'stage-timer']);
+  }
+
+  protected async openTimer(timer: StageTimer): Promise<void> {
+    await this.router.navigate(['/tools', 'stage-timer', 'presenter', timer.code]);
+  }
+
+  protected trackByTimer(_: number, timer: StageTimer): string {
+    return timer.id;
+  }
+}

--- a/src/app/tools/stage-timer-presenter/stage-timer-presenter.component.html
+++ b/src/app/tools/stage-timer-presenter/stage-timer-presenter.component.html
@@ -1,0 +1,79 @@
+<section class="presenter-view" *ngIf="timer$ | async as timer; else notFound">
+  <header class="presenter-view__header">
+    <div>
+      <p class="presenter-view__eyebrow">Stage Timer · Code {{ timer.code }}</p>
+      <h1>{{ timer.name }}</h1>
+    </div>
+    <div class="presenter-view__header-actions">
+      <span class="presenter-view__status" [ngClass]="'status--' + timer.status">
+        {{ timerStatus(timer) }}
+      </span>
+      <a class="presenter-view__back" (click)="goHome()">Back to Stage Timer</a>
+    </div>
+  </header>
+
+  <div class="presenter-view__grid">
+    <section class="presenter-view__main">
+      <div class="presenter-view__time">{{ formatTime(timer.remainingSeconds) }}</div>
+      <div class="presenter-view__timeline">
+        <div class="presenter-view__timeline-fill" [style.width.%]="timerProgress(timer)"></div>
+      </div>
+      <div class="presenter-view__meta">
+        <div>
+          <span class="label">Duration</span>
+          <span class="value">{{ formatTime(timer.durationSeconds) }}</span>
+        </div>
+        <div>
+          <span class="label">Remaining</span>
+          <span class="value">{{ formatTime(timer.remainingSeconds) }}</span>
+        </div>
+      </div>
+    </section>
+
+    <aside class="presenter-view__sidebar">
+      <section class="presenter-view__notes">
+        <header>
+          <h2>Show notes</h2>
+          <p>Stay aligned with the production team in real-time.</p>
+        </header>
+        <ul *ngIf="notesFor(timer) as notes">
+          <li *ngFor="let note of notes">
+            <span class="time">{{ note.createdAt | date: 'shortTime' }}</span>
+            <span class="body">{{ note.body }}</span>
+          </li>
+          <li *ngIf="!notes.length" class="empty">No notes yet.</li>
+        </ul>
+      </section>
+    </aside>
+  </div>
+
+  <div
+    class="presenter-view__urgent"
+    *ngIf="urgentNoteFor(timer) as urgent"
+    [class.presenter-view__urgent--acknowledged]="urgent.acknowledgedAt"
+  >
+    <div class="presenter-view__urgent-content">
+      <div class="presenter-view__urgent-title">
+        <span>Urgent note</span>
+        <span class="time">Sent {{ urgent.createdAt | date: 'shortTime' }}</span>
+      </div>
+      <p>{{ urgent.body }}</p>
+      <div class="presenter-view__urgent-footer">
+        <span *ngIf="urgent.acknowledgedAt" class="ack">
+          Acknowledged {{ urgent.acknowledgedAt | date: 'shortTime' }}
+        </span>
+        <button type="button" (click)="acknowledge(timer)">
+          {{ urgent.acknowledgedAt ? 'Dismiss' : 'Acknowledge' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<ng-template #notFound>
+  <section class="presenter-view presenter-view--empty">
+    <h1>Timer not found</h1>
+    <p>We couldn't find a timer for the code <strong>{{ code }}</strong>.</p>
+    <a class="presenter-view__back" routerLink="../../stage-timer">Back to Stage Timer</a>
+  </section>
+</ng-template>

--- a/src/app/tools/stage-timer-presenter/stage-timer-presenter.component.scss
+++ b/src/app/tools/stage-timer-presenter/stage-timer-presenter.component.scss
@@ -1,0 +1,319 @@
+@use '../../../style/colors.scss' as *;
+
+:host {
+  display: block;
+  height: 100%;
+}
+
+.presenter-view {
+  min-height: 100%;
+  padding: 2.5rem;
+  background: radial-gradient(circle at top right, rgba($accent-color, 0.08), transparent),
+    linear-gradient(180deg, rgba($main-light-color, 0.96), rgba($main-light-color, 0.9));
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: relative;
+}
+
+.presenter-view__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.presenter-view__eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: rgba($main-text-color, 0.6);
+}
+
+.presenter-view__header h1 {
+  margin: 0.2rem 0 0;
+  font-size: clamp(2.4rem, 3vw, 3.2rem);
+}
+
+.presenter-view__status {
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  background-color: rgba($main-text-color, 0.12);
+  color: $main-text-color;
+}
+
+.status--running {
+  background-color: rgba(#00a76f, 0.18);
+  color: #007350;
+}
+
+.status--paused {
+  background-color: rgba(#fbbc05, 0.18);
+  color: #a96a00;
+}
+
+.status--completed {
+  background-color: rgba(#5f6368, 0.24);
+  color: #3c4043;
+}
+
+.presenter-view__back {
+  color: $accent-color;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.presenter-view__back:hover {
+  text-decoration: underline;
+}
+
+.presenter-view__grid {
+  display: grid;
+  grid-template-columns: 2fr minmax(260px, 1fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.presenter-view__main {
+  background: rgba($main-light-color, 0.95);
+  border-radius: $major-border-radius;
+  padding: clamp(2rem, 3vw, 3rem);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.presenter-view__time {
+  font-size: clamp(4.5rem, 12vw, 8rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+.presenter-view__timeline {
+  height: 16px;
+  background: rgba($main-text-color, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.presenter-view__timeline-fill {
+  height: 100%;
+  background: linear-gradient(90deg, $accent-color, lighten($accent-color, 15%));
+  transition: width 0.4s ease;
+}
+
+.presenter-view__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: rgba($main-text-color, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.9rem;
+}
+
+.presenter-view__meta .value {
+  display: block;
+  font-size: 1.4rem;
+  letter-spacing: 0.04em;
+}
+
+.presenter-view__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.presenter-view__notes {
+  background: rgba($main-light-color, 0.96);
+  border-radius: $major-border-radius;
+  padding: 1.5rem;
+  box-shadow: 0 20px 46px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.presenter-view__notes header h2 {
+  margin: 0;
+}
+
+.presenter-view__notes header p {
+  margin: 0.4rem 0 0;
+  color: rgba($main-text-color, 0.6);
+}
+
+.presenter-view__notes ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.presenter-view__notes li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: $minor-border-radius;
+  background: rgba($accent-color, 0.08);
+}
+
+.presenter-view__notes .time {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: rgba($main-text-color, 0.6);
+  text-transform: uppercase;
+}
+
+.presenter-view__notes .body {
+  font-size: 1rem;
+}
+
+.presenter-view__notes .empty {
+  text-align: center;
+  color: rgba($main-text-color, 0.55);
+  background: rgba($main-text-color, 0.05);
+}
+
+.presenter-view__urgent {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 20;
+  animation: fadeIn 0.2s ease;
+}
+
+.presenter-view__urgent-content {
+  background: #fff6f6;
+  border-radius: 24px;
+  border: 2px solid rgba(#d93025, 0.6);
+  padding: 2rem;
+  max-width: 680px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.24);
+}
+
+.presenter-view__urgent--acknowledged .presenter-view__urgent-content {
+  background: #effaf4;
+  border-color: rgba(#00a76f, 0.6);
+}
+
+.presenter-view__urgent-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: #d93025;
+}
+
+.presenter-view__urgent--acknowledged .presenter-view__urgent-title {
+  color: #007350;
+}
+
+.presenter-view__urgent-title .time {
+  font-size: 0.75rem;
+}
+
+.presenter-view__urgent-content p {
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.5;
+}
+
+.presenter-view__urgent-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.presenter-view__urgent-footer button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.6rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: #d93025;
+  color: #fff;
+  transition: $quick-transition;
+}
+
+.presenter-view__urgent--acknowledged .presenter-view__urgent-footer button {
+  background: #00a76f;
+}
+
+.presenter-view__urgent-footer button:hover {
+  filter: brightness(0.92);
+}
+
+.presenter-view__urgent-footer .ack {
+  font-size: 0.85rem;
+  color: rgba(#d93025, 0.9);
+}
+
+.presenter-view__urgent--acknowledged .presenter-view__urgent-footer .ack {
+  color: rgba(#007350, 0.9);
+}
+
+.presenter-view--empty {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 1rem;
+}
+
+.presenter-view--empty h1 {
+  margin: 0;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 1024px) {
+  .presenter-view__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .presenter-view__main {
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .presenter-view {
+    padding: 1.5rem;
+  }
+
+  .presenter-view__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/app/tools/stage-timer-presenter/stage-timer-presenter.component.ts
+++ b/src/app/tools/stage-timer-presenter/stage-timer-presenter.component.ts
@@ -1,0 +1,73 @@
+import { AsyncPipe, DatePipe, NgClass, NgFor, NgIf } from '@angular/common';
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { map, switchMap, tap } from 'rxjs';
+import { StageTimer, StageTimerNote, StageTimerUrgentNote } from '../stage-timer.models';
+import { StageTimerService } from '../stage-timer.service';
+
+@Component({
+  selector: 'stage-timer-presenter',
+  standalone: true,
+  imports: [AsyncPipe, DatePipe, NgClass, NgFor, NgIf, RouterLink],
+  templateUrl: './stage-timer-presenter.component.html',
+  styleUrl: './stage-timer-presenter.component.scss',
+})
+export class StageTimerPresenterComponent implements OnInit {
+  private readonly stageTimerService = inject(StageTimerService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  protected code = '';
+
+  protected readonly timer$ = this.route.paramMap.pipe(
+    map((params) => (params.get('code') ?? '').toUpperCase()),
+    tap((code) => (this.code = code)),
+    switchMap((code) => this.stageTimerService.timerByCode$(code)),
+  );
+
+  async ngOnInit(): Promise<void> {
+    await this.stageTimerService.loadTimers();
+  }
+
+  protected formatTime(totalSeconds: number): string {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+    return `${this.pad(minutes)}:${this.pad(seconds)}`;
+  }
+
+  protected timerProgress(timer: StageTimer): number {
+    if (!timer.durationSeconds) return 0;
+    const elapsed = timer.durationSeconds - timer.remainingSeconds;
+    return Math.min(100, Math.max(0, (elapsed / timer.durationSeconds) * 100));
+  }
+
+  protected timerStatus(timer: StageTimer): string {
+    const status = timer.status;
+    if (status === 'running') return 'Running';
+    if (status === 'paused') return 'Paused';
+    if (status === 'completed') return 'Completed';
+    return 'Idle';
+  }
+
+  protected notesFor(timer: StageTimer): StageTimerNote[] {
+    return [...timer.notes].sort((a, b) =>
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+  }
+
+  protected urgentNoteFor(timer: StageTimer): StageTimerUrgentNote | null {
+    return timer.urgentNote ?? null;
+  }
+
+  protected async acknowledge(timer: StageTimer): Promise<void> {
+    await this.stageTimerService.acknowledgeUrgentNote(timer.id);
+  }
+
+  protected async goHome(): Promise<void> {
+    await this.router.navigate(['/tools', 'stage-timer']);
+  }
+
+  private pad(value: number): string {
+    return value.toString().padStart(2, '0');
+  }
+}

--- a/src/app/tools/stage-timer.models.ts
+++ b/src/app/tools/stage-timer.models.ts
@@ -1,0 +1,44 @@
+export type StageTimerStatus = 'idle' | 'running' | 'paused' | 'completed';
+
+export interface StageTimerNote {
+  id: string;
+  timerId: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface StageTimerUrgentNote {
+  id: string;
+  timerId: string;
+  body: string;
+  createdAt: string;
+  acknowledgedAt: string | null;
+}
+
+export interface StageTimer {
+  id: string;
+  orgSlug: string;
+  sceneId: string;
+  name: string;
+  durationSeconds: number;
+  remainingSeconds: number;
+  status: StageTimerStatus;
+  code: string;
+  startAt: string | null;
+  endAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  notes: StageTimerNote[];
+  urgentNote: StageTimerUrgentNote | null;
+}
+
+export interface CreateStageTimerPayload {
+  name: string;
+  durationMinutes: number;
+  durationSeconds: number;
+  sceneId?: string;
+}
+
+export interface StageTimerSnapshot {
+  timers: StageTimer[];
+}

--- a/src/app/tools/stage-timer.service.ts
+++ b/src/app/tools/stage-timer.service.ts
@@ -1,0 +1,488 @@
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, Observable, map } from 'rxjs';
+import { AuthService } from '../auth/auth.service';
+import { SupabaseService } from '../shared/supabase-service/supabase.service';
+import { environment } from '../../environments/environment';
+import {
+  CreateStageTimerPayload,
+  StageTimer,
+  StageTimerNote,
+  StageTimerSnapshot,
+  StageTimerStatus,
+  StageTimerUrgentNote,
+} from './stage-timer.models';
+
+interface EdgeResponse<T> {
+  data?: T;
+  timers?: StageTimer[];
+  timer?: StageTimer;
+  note?: StageTimerNote;
+  urgentNote?: StageTimerUrgentNote | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StageTimerService {
+  private readonly supabaseService = inject(SupabaseService);
+  private readonly authService = inject(AuthService);
+
+  private readonly edgeFunctionName = environment.stageTimerEdgeFunction;
+  private readonly timersSubject = new BehaviorSubject<StageTimer[]>([]);
+  private readonly tickers = new Map<string, number>();
+  private hasLoaded = false;
+
+  readonly timers$ = this.timersSubject.asObservable();
+
+  constructor() {
+    const snapshot = this.readSnapshotFromStorage();
+    if (snapshot) {
+      this.applySnapshot(snapshot);
+    }
+  }
+
+  get orgSlug(): string {
+    return this.authService.orgSlug || environment.defaultOrgSlug;
+  }
+
+  async loadTimers(): Promise<void> {
+    if (this.hasLoaded) return;
+    this.hasLoaded = true;
+
+    const remote = await this.fetchFromEdge();
+    if (remote && remote.length) {
+      this.applySnapshot({ timers: remote });
+    }
+  }
+
+  async createTimer(payload: CreateStageTimerPayload): Promise<StageTimer> {
+    await this.loadTimers();
+
+    const durationSeconds = Math.max(
+      0,
+      payload.durationMinutes * 60 + payload.durationSeconds,
+    );
+    const now = new Date().toISOString();
+    const timer: StageTimer = {
+      id: this.generateId(),
+      orgSlug: this.orgSlug,
+      sceneId: payload.sceneId ?? 'master',
+      name: payload.name.trim() || 'Untitled Timer',
+      durationSeconds,
+      remainingSeconds: durationSeconds,
+      status: 'idle',
+      code: this.generateCode(),
+      startAt: null,
+      endAt: null,
+      createdAt: now,
+      updatedAt: now,
+      notes: [],
+      urgentNote: null,
+    };
+
+    this.upsertTimer(timer);
+    await this.persistTimerToEdge(timer, 'create_timer');
+    return timer;
+  }
+
+  async startTimer(timerId: string): Promise<void> {
+    const updated = await this.updateTimer(timerId, (timer) => {
+      if (timer.status === 'running') return timer;
+      const now = new Date().toISOString();
+      return {
+        ...timer,
+        status: 'running',
+        startAt: timer.startAt ?? now,
+        updatedAt: now,
+      };
+    });
+    if (updated) {
+      this.startTicker(updated.id);
+      await this.persistTimerToEdge(updated, 'update_timer');
+    }
+  }
+
+  async pauseTimer(timerId: string): Promise<void> {
+    this.stopTicker(timerId);
+    const updated = await this.updateTimer(timerId, (timer) => {
+      if (timer.status !== 'running') return timer;
+      return {
+        ...timer,
+        status: 'paused',
+        updatedAt: new Date().toISOString(),
+      };
+    });
+    if (updated) {
+      await this.persistTimerToEdge(updated, 'update_timer');
+    }
+  }
+
+  async resetTimer(timerId: string): Promise<void> {
+    this.stopTicker(timerId);
+    const updated = await this.updateTimer(timerId, (timer) => ({
+      ...timer,
+      status: 'idle',
+      remainingSeconds: timer.durationSeconds,
+      startAt: null,
+      endAt: null,
+      updatedAt: new Date().toISOString(),
+    }));
+    if (updated) {
+      await this.persistTimerToEdge(updated, 'update_timer');
+    }
+  }
+
+  async completeTimer(timerId: string): Promise<void> {
+    this.stopTicker(timerId);
+    const updated = await this.updateTimer(timerId, (timer) => ({
+      ...timer,
+      status: 'completed',
+      remainingSeconds: 0,
+      endAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+    if (updated) {
+      await this.persistTimerToEdge(updated, 'update_timer');
+    }
+  }
+
+  async deleteTimer(timerId: string): Promise<void> {
+    this.stopTicker(timerId);
+    const timers = this.timersSubject.getValue();
+    const next = timers.filter((timer) => timer.id !== timerId);
+    if (next.length === timers.length) return;
+    this.timersSubject.next(next);
+    this.persistSnapshot();
+    await this.invokeEdge('delete_timer', { timerId });
+  }
+
+  async addNote(timerId: string, body: string): Promise<StageTimerNote | null> {
+    const trimmed = body.trim();
+    if (!trimmed) return null;
+
+    const note: StageTimerNote = {
+      id: this.generateId(),
+      timerId,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+    };
+
+    const updated = await this.updateTimer(timerId, (timer) => ({
+      ...timer,
+      notes: [...timer.notes, note],
+      updatedAt: note.createdAt,
+    }));
+
+    if (updated) {
+      await this.invokeEdge('add_note', { timerId, note });
+      return note;
+    }
+    return null;
+  }
+
+  async addUrgentNote(
+    timerId: string,
+    body: string,
+  ): Promise<StageTimerUrgentNote | null> {
+    const trimmed = body.trim();
+    if (!trimmed) return null;
+
+    const urgentNote: StageTimerUrgentNote = {
+      id: this.generateId(),
+      timerId,
+      body: trimmed,
+      createdAt: new Date().toISOString(),
+      acknowledgedAt: null,
+    };
+
+    const updated = await this.updateTimer(timerId, (timer) => ({
+      ...timer,
+      urgentNote,
+      updatedAt: urgentNote.createdAt,
+    }));
+
+    if (updated) {
+      await this.invokeEdge('add_urgent_note', { timerId, urgentNote });
+      return urgentNote;
+    }
+    return null;
+  }
+
+  async acknowledgeUrgentNote(timerId: string): Promise<void> {
+    const updated = await this.updateTimer(timerId, (timer) => {
+      if (!timer.urgentNote) return timer;
+      return {
+        ...timer,
+        urgentNote: {
+          ...timer.urgentNote,
+          acknowledgedAt: new Date().toISOString(),
+        },
+        updatedAt: new Date().toISOString(),
+      };
+    });
+
+    if (updated && updated.urgentNote) {
+      await this.invokeEdge('acknowledge_urgent_note', {
+        timerId,
+        urgentNoteId: updated.urgentNote.id,
+      });
+    }
+  }
+
+  async clearUrgentNote(timerId: string): Promise<void> {
+    const updated = await this.updateTimer(timerId, (timer) => ({
+      ...timer,
+      urgentNote: null,
+      updatedAt: new Date().toISOString(),
+    }));
+
+    if (updated) {
+      await this.invokeEdge('clear_urgent_note', { timerId });
+    }
+  }
+
+  timerByCode$(code: string): Observable<StageTimer | null> {
+    return this.timers$.pipe(
+      map((timers) =>
+        timers.find((timer) =>
+          timer.code.toLowerCase() === code.toLowerCase()
+        ) ?? null,
+      ),
+    );
+  }
+
+  getTimerByCode(code: string): StageTimer | null {
+    const timers = this.timersSubject.getValue();
+    return (
+      timers.find((timer) => timer.code.toLowerCase() === code.toLowerCase()) ||
+      null
+    );
+  }
+
+  stopTicker(timerId: string): void {
+    const handle = this.tickers.get(timerId);
+    if (handle) {
+      clearInterval(handle);
+      this.tickers.delete(timerId);
+    }
+  }
+
+  private async fetchFromEdge(): Promise<StageTimer[] | null> {
+    if (!this.edgeFunctionName) return null;
+    const payload = await this.invokeEdge<StageTimerSnapshot>('list', {});
+    if (!payload) return null;
+
+    if (Array.isArray(payload.timers)) {
+      return payload.timers.map((timer) => this.withDefaults(timer));
+    }
+    if (Array.isArray((payload as unknown as StageTimer[]))) {
+      return (payload as unknown as StageTimer[]).map((timer) =>
+        this.withDefaults(timer)
+      );
+    }
+    return null;
+  }
+
+  private applySnapshot(snapshot: StageTimerSnapshot): void {
+    const timers = (snapshot.timers ?? []).map((timer) =>
+      this.withDefaults(timer),
+    );
+    this.timersSubject.next(timers);
+    this.persistSnapshot();
+  }
+
+  private withDefaults(timer: StageTimer): StageTimer {
+    return {
+      ...timer,
+      orgSlug: timer.orgSlug || this.orgSlug,
+      sceneId: timer.sceneId || 'master',
+      name: timer.name || 'Untitled Timer',
+      durationSeconds: timer.durationSeconds ?? timer.remainingSeconds ?? 0,
+      remainingSeconds:
+        timer.remainingSeconds ?? timer.durationSeconds ?? 0,
+      status: (timer.status as StageTimerStatus) || 'idle',
+      code: timer.code || this.generateCode(),
+      startAt: timer.startAt ?? null,
+      endAt: timer.endAt ?? null,
+      createdAt: timer.createdAt ?? new Date().toISOString(),
+      updatedAt: timer.updatedAt ?? new Date().toISOString(),
+      notes: Array.isArray(timer.notes)
+        ? timer.notes.map((note) => ({ ...note }))
+        : [],
+      urgentNote: timer.urgentNote
+        ? { ...timer.urgentNote }
+        : null,
+    };
+  }
+
+  private upsertTimer(timer: StageTimer): void {
+    const timers = this.timersSubject.getValue();
+    const index = timers.findIndex((item) => item.id === timer.id);
+    const next = [...timers];
+    if (index >= 0) {
+      next[index] = timer;
+    } else {
+      next.push(timer);
+    }
+    this.timersSubject.next(next);
+    this.persistSnapshot();
+  }
+
+  private async updateTimer(
+    timerId: string,
+    mutator: (timer: StageTimer) => StageTimer,
+  ): Promise<StageTimer | null> {
+    const timers = this.timersSubject.getValue();
+    const index = timers.findIndex((timer) => timer.id === timerId);
+    if (index === -1) return null;
+    const current = this.cloneTimer(timers[index]);
+    const updated = this.withDefaults(mutator(current));
+    const next = [...timers];
+    next[index] = updated;
+    this.timersSubject.next(next);
+    this.persistSnapshot();
+    return updated;
+  }
+
+  private startTicker(timerId: string): void {
+    this.stopTicker(timerId);
+    const scheduler =
+      typeof window !== 'undefined' && typeof window.setInterval === 'function'
+        ? window.setInterval.bind(window)
+        : setInterval;
+    const handle = scheduler(() => {
+      this.tick(timerId);
+    }, 1000);
+    this.tickers.set(timerId, handle as unknown as number);
+  }
+
+  private tick(timerId: string): void {
+    const timers = this.timersSubject.getValue();
+    const index = timers.findIndex((timer) => timer.id === timerId);
+    if (index === -1) {
+      this.stopTicker(timerId);
+      return;
+    }
+
+    const timer = timers[index];
+    if (timer.status !== 'running') {
+      this.stopTicker(timerId);
+      return;
+    }
+
+    const remaining = Math.max(0, timer.remainingSeconds - 1);
+    const updated: StageTimer = {
+      ...timer,
+      remainingSeconds: remaining,
+      status: remaining === 0 ? 'completed' : timer.status,
+      endAt:
+        remaining === 0 && !timer.endAt
+          ? new Date().toISOString()
+          : timer.endAt,
+      updatedAt: new Date().toISOString(),
+    };
+
+    const next = [...timers];
+    next[index] = updated;
+    this.timersSubject.next(next);
+    this.persistSnapshot();
+
+    if (remaining === 0) {
+      this.stopTicker(timerId);
+      void this.persistTimerToEdge(updated, 'update_timer');
+    }
+  }
+
+  private persistSnapshot(): void {
+    if (typeof window === 'undefined') return;
+    try {
+      const snapshot: StageTimerSnapshot = {
+        timers: this.timersSubject.getValue(),
+      };
+      window.localStorage.setItem(
+        this.storageKey(),
+        JSON.stringify(snapshot),
+      );
+    } catch (error) {
+      console.warn('Unable to persist stage timer snapshot', error);
+    }
+  }
+
+  private readSnapshotFromStorage(): StageTimerSnapshot | null {
+    if (typeof window === 'undefined') return null;
+    try {
+      const raw = window.localStorage.getItem(this.storageKey());
+      if (!raw) return null;
+      return JSON.parse(raw) as StageTimerSnapshot;
+    } catch (error) {
+      console.warn('Unable to read stage timer snapshot', error);
+      return null;
+    }
+  }
+
+  private storageKey(): string {
+    return `stage-timers:${this.orgSlug}`;
+  }
+
+  private cloneTimer(timer: StageTimer): StageTimer {
+    return {
+      ...timer,
+      notes: timer.notes.map((note) => ({ ...note })),
+      urgentNote: timer.urgentNote ? { ...timer.urgentNote } : null,
+    };
+  }
+
+  private generateCode(): string {
+    const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let code = '';
+    do {
+      code = Array.from({ length: 5 })
+        .map(
+          () => alphabet[Math.floor(Math.random() * alphabet.length)] ?? 'A',
+        )
+        .join('');
+    } while (this.timersSubject.getValue().some((timer) => timer.code === code));
+    return code;
+  }
+
+  private generateId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+    return Math.random().toString(36).slice(2);
+  }
+
+  private async persistTimerToEdge(
+    timer: StageTimer,
+    action: 'create_timer' | 'update_timer',
+  ): Promise<void> {
+    await this.invokeEdge(action, { timer });
+  }
+
+  private async invokeEdge<T = EdgeResponse<unknown>>(
+    action: string,
+    body: Record<string, unknown>,
+  ): Promise<T | null> {
+    if (!this.edgeFunctionName) return null;
+    try {
+      const { data, error } = await this.supabaseService.client.functions.invoke(
+        this.edgeFunctionName,
+        {
+          body: { action, ...body },
+          headers: this.orgHeaders(),
+        },
+      );
+      if (error) throw error;
+      return data as T;
+    } catch (error) {
+      console.warn(`Stage timer edge function ${action} failed`, error);
+      return null;
+    }
+  }
+
+  private orgHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (this.orgSlug) {
+      headers['x-org-slug'] = this.orgSlug;
+    }
+    return headers;
+  }
+}

--- a/src/app/tools/tools.component.html
+++ b/src/app/tools/tools.component.html
@@ -1,0 +1,5 @@
+<ui-shell>
+  <content>
+    <router-outlet />
+  </content>
+</ui-shell>

--- a/src/app/tools/tools.component.scss
+++ b/src/app/tools/tools.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+content {
+  width: 100%;
+}

--- a/src/app/tools/tools.component.ts
+++ b/src/app/tools/tools.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { UiShellComponent } from '../shared/ui-shell/ui-shell-component';
+
+@Component({
+  selector: 'tools-component',
+  standalone: true,
+  imports: [UiShellComponent, RouterOutlet],
+  templateUrl: './tools.component.html',
+  styleUrl: './tools.component.scss',
+})
+export class ToolsComponent {}

--- a/src/app/tools/tools.routes.ts
+++ b/src/app/tools/tools.routes.ts
@@ -1,0 +1,37 @@
+import { Routes } from '@angular/router';
+import { ToolsComponent } from './tools.component';
+
+export const ToolsRoutes: Routes = [
+  {
+    path: '',
+    component: ToolsComponent,
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        redirectTo: 'stage-timer',
+      },
+      {
+        path: 'stage-timer',
+        loadComponent: () =>
+          import('./stage-timer-dashboard/stage-timer-dashboard.component').then(
+            (m) => m.StageTimerDashboardComponent,
+          ),
+      },
+      {
+        path: 'stage-timer/presenter',
+        loadComponent: () =>
+          import('./stage-timer-presenter-access/stage-timer-presenter-access.component').then(
+            (m) => m.StageTimerPresenterAccessComponent,
+          ),
+      },
+      {
+        path: 'stage-timer/presenter/:code',
+        loadComponent: () =>
+          import('./stage-timer-presenter/stage-timer-presenter.component').then(
+            (m) => m.StageTimerPresenterComponent,
+          ),
+      },
+    ],
+  },
+];

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,4 +8,5 @@ export const environment = {
   vehiclePortalAdminSecret: 'development-admin-secret',
   baseTenantDomain: 'cue-rms.com',
   defaultOrgSlug: 'public',
+  stageTimerEdgeFunction: 'stage-timer',
 };

--- a/supabase/stage-timer-edge-function.ts
+++ b/supabase/stage-timer-edge-function.ts
@@ -1,0 +1,368 @@
+// Supabase Edge Function for Stage Timer operations.
+// Deploy as functions/stage-timer/index.ts in your Supabase project.
+
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type, x-org-slug',
+};
+
+type TimerRow = {
+  id: string;
+  org_slug: string;
+  scene_id: string;
+  name: string;
+  duration_seconds: number;
+  remaining_seconds: number;
+  status: string;
+  code: string;
+  start_at: string | null;
+  end_at: string | null;
+  created_at: string;
+  updated_at: string;
+  notes?: NoteRow[];
+};
+
+type NoteRow = {
+  id: string;
+  org_slug: string;
+  timer_id: string;
+  body: string;
+  is_urgent: boolean;
+  created_at: string;
+  acknowledged_at: string | null;
+};
+
+type StageTimerPayload = {
+  id: string;
+  sceneId?: string;
+  name?: string;
+  durationSeconds?: number;
+  remainingSeconds?: number;
+  status?: string;
+  code: string;
+  startAt?: string | null;
+  endAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type StageTimerNotePayload = {
+  id: string;
+  body: string;
+  createdAt?: string;
+  acknowledgedAt?: string | null;
+};
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+if (!supabaseUrl || !supabaseServiceRoleKey) {
+  console.warn('Supabase environment variables are not set for stage-timer edge.');
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const payload = (await req.json()) as Record<string, unknown>;
+    const rawAction = payload['action'];
+    if (typeof rawAction !== 'string') {
+      return json({ error: 'Action is required' }, 400);
+    }
+    const action = rawAction;
+    const orgSlug = (req.headers.get('x-org-slug') ?? 'public').toLowerCase();
+
+    const client = createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: { persistSession: false },
+    });
+
+    await ensureMasterScene(client, orgSlug);
+
+    let result: unknown = { ok: true };
+
+    switch (action) {
+      case 'list':
+        result = await listTimers(client, orgSlug);
+        break;
+      case 'create_timer':
+        result = await upsertTimer(
+          client,
+          orgSlug,
+          (payload['timer'] as StageTimerPayload | undefined) ?? null,
+        );
+        break;
+      case 'update_timer':
+        result = await upsertTimer(
+          client,
+          orgSlug,
+          (payload['timer'] as StageTimerPayload | undefined) ?? null,
+        );
+        break;
+      case 'delete_timer':
+        result = await deleteTimer(
+          client,
+          orgSlug,
+          (payload['timerId'] as string | undefined) ?? '',
+        );
+        break;
+      case 'add_note':
+        result = await addNote(
+          client,
+          orgSlug,
+          (payload['timerId'] as string | undefined) ?? '',
+          (payload['note'] as StageTimerNotePayload | undefined) ?? null,
+          false,
+        );
+        break;
+      case 'add_urgent_note':
+        result = await addNote(
+          client,
+          orgSlug,
+          (payload['timerId'] as string | undefined) ?? '',
+          (payload['urgentNote'] as StageTimerNotePayload | undefined) ?? null,
+          true,
+        );
+        break;
+      case 'acknowledge_urgent_note':
+        result = await acknowledgeUrgentNote(
+          client,
+          orgSlug,
+          (payload['timerId'] as string | undefined) ?? '',
+          (payload['urgentNoteId'] as string | undefined) ?? '',
+        );
+        break;
+      case 'clear_urgent_note':
+        result = await clearUrgentNotes(
+          client,
+          orgSlug,
+          (payload['timerId'] as string | undefined) ?? '',
+        );
+        break;
+      default:
+        return json({ error: `Unsupported action: ${action}` }, 400);
+    }
+
+    return json(result ?? { ok: true });
+  } catch (error) {
+    console.error('Stage timer edge error', error);
+    return json({ error: error?.message ?? 'Unexpected error' }, 500);
+  }
+}, { addr: ':8000' });
+
+async function ensureMasterScene(client: ReturnType<typeof createClient>, orgSlug: string) {
+  const { error } = await client.rpc('ensure_stage_timer_master_scene', {
+    target_org: orgSlug,
+  });
+  if (error) {
+    console.error('Failed to ensure master scene', error);
+  }
+}
+
+async function listTimers(client: ReturnType<typeof createClient>, orgSlug: string) {
+  const { data, error } = await client
+    .from('stage_timer_timers')
+    .select(
+      `id, org_slug, scene_id, name, duration_seconds, remaining_seconds, status, code, start_at, end_at, created_at, updated_at,
+        notes:stage_timer_notes (id, org_slug, timer_id, body, is_urgent, created_at, acknowledged_at)`,
+    )
+    .eq('org_slug', orgSlug)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+
+  const timers = (data ?? []).map((row) => mapTimer(row as TimerRow));
+  return { timers };
+}
+
+async function upsertTimer(
+  client: ReturnType<typeof createClient>,
+  orgSlug: string,
+  timer: StageTimerPayload | null,
+) {
+  if (!timer) return { ok: true };
+
+  const payload = {
+    id: timer.id,
+    org_slug: orgSlug,
+    scene_id: timer.sceneId ?? (await getMasterSceneId(client, orgSlug)),
+    name: timer.name ?? 'Untitled Timer',
+    duration_seconds: timer.durationSeconds ?? 0,
+    remaining_seconds: timer.remainingSeconds ?? timer.durationSeconds ?? 0,
+    status: timer.status ?? 'idle',
+    code: timer.code,
+    start_at: timer.startAt ?? null,
+    end_at: timer.endAt ?? null,
+    created_at: timer.createdAt ?? new Date().toISOString(),
+    updated_at: timer.updatedAt ?? new Date().toISOString(),
+  };
+
+  const { data, error } = await client
+    .from('stage_timer_timers')
+    .upsert(payload, { onConflict: 'id' })
+    .select(
+      `id, org_slug, scene_id, name, duration_seconds, remaining_seconds, status, code, start_at, end_at, created_at, updated_at,
+        notes:stage_timer_notes (id, org_slug, timer_id, body, is_urgent, created_at, acknowledged_at)`,
+    )
+    .eq('org_slug', orgSlug)
+    .eq('id', payload.id)
+    .single();
+
+  if (error) throw error;
+  return { timer: mapTimer(data as TimerRow) };
+}
+
+async function deleteTimer(
+  client: ReturnType<typeof createClient>,
+  orgSlug: string,
+  timerId: string,
+) {
+  if (!timerId) return { ok: true };
+  const { error } = await client
+    .from('stage_timer_timers')
+    .delete()
+    .eq('org_slug', orgSlug)
+    .eq('id', timerId);
+  if (error) throw error;
+  return { ok: true };
+}
+
+async function addNote(
+  client: ReturnType<typeof createClient>,
+  orgSlug: string,
+  timerId: string,
+  note: StageTimerNotePayload | null,
+  isUrgent: boolean,
+) {
+  if (!timerId || !note) return { ok: true };
+  const payload = {
+    id: note.id,
+    org_slug: orgSlug,
+    timer_id: timerId,
+    body: note.body,
+    is_urgent: isUrgent,
+    created_at: note.createdAt ?? new Date().toISOString(),
+    acknowledged_at: note.acknowledgedAt ?? null,
+  };
+
+  const { data, error } = await client
+    .from('stage_timer_notes')
+    .upsert(payload, { onConflict: 'id' })
+    .select('id, org_slug, timer_id, body, is_urgent, created_at, acknowledged_at')
+    .single();
+
+  if (error) throw error;
+
+  if (isUrgent) {
+    return { urgentNote: mapUrgent(data as NoteRow) };
+  }
+
+  return { note: mapNote(data as NoteRow) };
+}
+
+async function acknowledgeUrgentNote(
+  client: ReturnType<typeof createClient>,
+  orgSlug: string,
+  timerId: string,
+  urgentNoteId: string,
+) {
+  if (!timerId || !urgentNoteId) return { ok: true };
+  const { data, error } = await client
+    .from('stage_timer_notes')
+    .update({ acknowledged_at: new Date().toISOString() })
+    .eq('org_slug', orgSlug)
+    .eq('timer_id', timerId)
+    .eq('id', urgentNoteId)
+    .eq('is_urgent', true)
+    .select('id, org_slug, timer_id, body, is_urgent, created_at, acknowledged_at')
+    .single();
+
+  if (error) throw error;
+  return { urgentNote: mapUrgent(data as NoteRow) };
+}
+
+async function clearUrgentNotes(
+  client: ReturnType<typeof createClient>,
+  orgSlug: string,
+  timerId: string,
+) {
+  if (!timerId) return { ok: true };
+  const { error } = await client
+    .from('stage_timer_notes')
+    .update({ acknowledged_at: new Date().toISOString() })
+    .eq('org_slug', orgSlug)
+    .eq('timer_id', timerId)
+    .eq('is_urgent', true)
+    .is('acknowledged_at', null);
+  if (error) throw error;
+  return { ok: true };
+}
+
+async function getMasterSceneId(
+  client: ReturnType<typeof createClient>,
+  orgSlug: string,
+): Promise<string> {
+  const { data, error } = await client
+    .from('stage_timer_scenes')
+    .select('id')
+    .eq('org_slug', orgSlug)
+    .eq('is_master', true)
+    .single();
+  if (error) throw error;
+  return data?.id as string;
+}
+
+function mapTimer(row: TimerRow) {
+  const notes = (row.notes ?? []).filter((note) => !note.is_urgent);
+  const urgentNotes = (row.notes ?? [])
+    .filter((note) => note.is_urgent)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
+  return {
+    id: row.id,
+    orgSlug: row.org_slug,
+    sceneId: row.scene_id,
+    name: row.name,
+    durationSeconds: row.duration_seconds,
+    remainingSeconds: row.remaining_seconds,
+    status: row.status,
+    code: row.code,
+    startAt: row.start_at,
+    endAt: row.end_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    notes: notes.map((note) => mapNote(note)),
+    urgentNote: urgentNotes.length ? mapUrgent(urgentNotes[0]) : null,
+  };
+}
+
+function mapNote(note: NoteRow) {
+  return {
+    id: note.id,
+    timerId: note.timer_id,
+    body: note.body,
+    createdAt: note.created_at,
+  };
+}
+
+function mapUrgent(note: NoteRow) {
+  return {
+    id: note.id,
+    timerId: note.timer_id,
+    body: note.body,
+    createdAt: note.created_at,
+    acknowledgedAt: note.acknowledged_at,
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders },
+  });
+}

--- a/supabase/stage-timer-schema.sql
+++ b/supabase/stage-timer-schema.sql
@@ -1,0 +1,79 @@
+-- Stage Timer schema
+-- Creates core tables for scenes, timers, and notes powering the Stage Timer tool.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists public.stage_timer_scenes (
+  id uuid primary key default gen_random_uuid(),
+  org_slug text not null,
+  name text not null,
+  is_master boolean not null default false,
+  created_at timestamptz not null default now(),
+  unique (org_slug, name)
+);
+
+create table if not exists public.stage_timer_timers (
+  id uuid primary key default gen_random_uuid(),
+  org_slug text not null,
+  scene_id uuid not null references public.stage_timer_scenes(id) on delete cascade,
+  name text not null,
+  duration_seconds integer not null default 0,
+  remaining_seconds integer not null default 0,
+  status text not null default 'idle',
+  code text not null,
+  start_at timestamptz,
+  end_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_slug, code)
+);
+
+create table if not exists public.stage_timer_notes (
+  id uuid primary key default gen_random_uuid(),
+  org_slug text not null,
+  timer_id uuid not null references public.stage_timer_timers(id) on delete cascade,
+  body text not null,
+  is_urgent boolean not null default false,
+  created_at timestamptz not null default now(),
+  acknowledged_at timestamptz
+);
+
+-- Grants for authenticated users via RLS. Adjust to match your security model.
+alter table public.stage_timer_scenes enable row level security;
+alter table public.stage_timer_timers enable row level security;
+alter table public.stage_timer_notes enable row level security;
+
+create policy "Scenes are per organisation"
+  on public.stage_timer_scenes
+  using (org_slug = coalesce(current_setting('request.jwt.claims', true)::json->>'org_slug', 'public'));
+
+create policy "Timers are per organisation"
+  on public.stage_timer_timers
+  using (org_slug = coalesce(current_setting('request.jwt.claims', true)::json->>'org_slug', 'public'));
+
+create policy "Notes are per organisation"
+  on public.stage_timer_notes
+  using (org_slug = coalesce(current_setting('request.jwt.claims', true)::json->>'org_slug', 'public'));
+
+-- Helper upsert to ensure a master scene exists per org.
+create or replace function public.ensure_stage_timer_master_scene(target_org text)
+returns uuid
+language plpgsql
+as $$
+declare
+  master_scene uuid;
+begin
+  select id into master_scene
+  from public.stage_timer_scenes
+  where org_slug = target_org and is_master = true
+  limit 1;
+
+  if master_scene is null then
+    insert into public.stage_timer_scenes (org_slug, name, is_master)
+    values (target_org, 'Master Scene', true)
+    returning id into master_scene;
+  end if;
+
+  return master_scene;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add a Tools navigation group that links to the new Stage Timer experience
- implement Stage Timer dashboard, presenter access, and presenter view screens with urgent note workflows
- scaffold Supabase schema and edge function for Stage Timer persistence and syncing

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a5ec616c83238998d24a575555f0)