### PR TITLE
Refine PartyHire order reconciliation and print layouts

### DIFF
--- a/src/app/partyhire/partyhire-component/partyhire.component.html
+++ b/src/app/partyhire/partyhire-component/partyhire.component.html
@@ -20,265 +20,358 @@
         </div>
       </header>
 
-      <section class="grid-layout">
-        <form class="card" [formGroup]="orderForm" (ngSubmit)="submitOrder()">
-          <div class="card-heading">
-            <div>
-              <p class="eyebrow">Create order</p>
-              <h2>Build a PartyHire sales order</h2>
-            </div>
-            <div class="calendar-message" *ngIf="calendarMessage">
-              {{ calendarMessage }}
-            </div>
-          </div>
-
-          <div class="form-grid">
-            <label>
-              <span>Customer / company</span>
-              <input
-                type="text"
-                formControlName="customerName"
-                placeholder="Client name"
-              />
-            </label>
-            <label>
-              <span>Contact email</span>
-              <input
-                type="email"
-                formControlName="contactEmail"
-                placeholder="ops@example.com"
-              />
-            </label>
-            <label>
-              <span>Contact phone</span>
-              <input
-                type="tel"
-                formControlName="contactPhone"
-                placeholder="+64..."
-              />
-            </label>
-            <label>
-              <span>Event name</span>
-              <input
-                type="text"
-                formControlName="eventName"
-                placeholder="Birthday, Wedding..."
-              />
-            </label>
-            <label>
-              <span>Start</span>
-              <input type="datetime-local" formControlName="startDate" />
-            </label>
-            <label>
-              <span>Return</span>
-              <input type="datetime-local" formControlName="endDate" />
-            </label>
-            <label>
-              <span>Location</span>
-              <input
-                type="text"
-                formControlName="location"
-                placeholder="Venue / address"
-              />
-            </label>
-            <label>
-              <span>Delivery method</span>
-              <select formControlName="deliveryMethod">
-                <option value="pickup">Pickup</option>
-                <option value="delivery">Delivery</option>
-              </select>
-            </label>
-            <label class="full-width">
-              <span>Calendar recipients (comma separated)</span>
-              <input
-                type="text"
-                formControlName="recipients"
-                placeholder="team@company.com, crew@company.com"
-              />
-            </label>
-            <label class="full-width">
-              <span>Notes for invoice / crew</span>
-              <textarea
-                formControlName="notes"
-                rows="2"
-                placeholder="Access times, parking, delivery instructions"
-              ></textarea>
-            </label>
-          </div>
-
-          <!-- ✅ wrap in formArrayName and use formGroupName -->
-          <div formArrayName="items">
-            <div
-              class="item-row"
-              *ngFor="
-                let item of itemsArray.controls;
-                let i = index;
-                trackBy: trackByControl
-              "
-              [formGroupName]="i"
-            >
-              <div class="item-select">
-                <label class="sr-only">Item</label>
-                <select formControlName="stockId">
-                  <option [ngValue]="null" disabled>Select an item</option>
-                  <option
-                    *ngFor="let stock of inventory; trackBy: trackByStockItem"
-                    [ngValue]="stock.id"
-                  >
-                    {{ stock.name }} ({{ stock.category }}) —
-                    {{ availableStock(stock) }} available
-                  </option>
-                </select>
-              </div>
-              <div class="item-qty">
-                <label class="sr-only">Qty</label>
-                <input type="number" min="1" formControlName="quantity" />
-              </div>
-              <div class="item-available" *ngIf="item.value.stockId">
-                <small>
-                  Reserved: {{ totalAllocated(item.value.stockId) }} •
-                  Remaining:
-                  {{ remainingStock(item.value.stockId) }}
-                </small>
-              </div>
-              <button
-                type="button"
-                class="ghost"
-                (click)="removeItemRow(i)"
-                [disabled]="itemsArray.length === 1"
-              >
-                Remove
-              </button>
-            </div>
-          </div>
-
-          <div class="actions">
-            <button type="submit" class="primary">Create sales order</button>
-            <button
-              type="button"
-              class="ghost"
-              (click)="
-                orderForm.reset({
-                  deliveryMethod: 'pickup',
-                  recipients: orderForm.value.recipients,
-                })
-              "
-            >
-              Clear
-            </button>
-          </div>
-        </form>
-
-        <div class="card secondary">
-          <div class="card-heading">
-            <div>
-              <p class="eyebrow">Stock snapshot</p>
-              <h3>PartyHire inventory bridge</h3>
-            </div>
-          </div>
-          <div class="stock-list">
-            <div
-              class="stock-row"
-              *ngFor="let item of inventory; trackBy: trackByStockItem"
-            >
-              <div>
-                <p class="stock-name">{{ item.name }}</p>
-                <p class="stock-meta">{{ item.category }}</p>
-              </div>
-              <div class="stock-badges">
-                <span class="pill">Total {{ item.total }}</span>
-                <span class="pill">Allocated {{ item.allocated }}</span>
-                <span class="pill strong">Free {{ availableStock(item) }}</span>
-              </div>
-            </div>
-          </div>
-          <div class="info-panel">
-            <h4>Automatic calendar entries</h4>
-            <p>
-              Every order builds a Google Calendar template with the formatted
-              summary, location and attendee list. Send it instantly to
-              subscribed users or re-open it from the order card to re-send.
-            </p>
-            <h4>Printable sales paperwork</h4>
-            <p>
-              Use the "Print sales order" action on any card to output the
-              quote/invoice format with item lines, totals and status legend.
-            </p>
-          </div>
-        </div>
-      </section>
-
       <section class="orders">
         <div class="section-heading">
           <div>
             <p class="eyebrow">Orders</p>
             <h2>Sales orders, quotes & status</h2>
+            <p class="muted">
+              Orders are grouped by the event date. Today's bookings are pinned
+              to the top for faster access.
+            </p>
+          </div>
+          <div class="section-actions">
+            <button
+              type="button"
+              class="ghost"
+              (click)="toggleArchived()"
+              aria-label="Toggle archived orders"
+            >
+              {{ showArchived ? 'Hide archived sales orders' : 'View archived sales orders' }}
+            </button>
+            <button
+              type="button"
+              class="primary"
+              (click)="openOrderModal()"
+            >
+              + Add sales order
+            </button>
+            <div class="calendar-message" *ngIf="calendarMessage">
+              {{ calendarMessage }}
+            </div>
           </div>
         </div>
 
-        <p class="empty" *ngIf="orders.length === 0">
+        <p class="empty" *ngIf="groupedOrders.length === 0">
           No partyhire orders yet. Add a sales order to reserve stock and build
           calendar invites.
         </p>
 
-        <article
-          *ngFor="let order of orders; trackBy: trackByOrder"
-          class="order-card"
-          [class.print-ready]="selectedPrintId === order.id"
+        <ng-container *ngFor="let group of groupedOrders">
+          <div class="order-group">
+            <div class="date-heading">
+              <p class="eyebrow">{{ group.label }}</p>
+              <p class="muted">{{ group.date | date: 'fullDate' }}</p>
+            </div>
+            <div class="order-list">
+              <article
+                *ngFor="let order of group.orders; trackBy: trackByOrder"
+                class="order-row"
+              >
+                <button
+                  type="button"
+                  class="order-summary"
+                  (click)="openOrderDetail(order)"
+                >
+                  <div>
+                    <p class="eyebrow">{{ order.reference }}</p>
+                    <h3>{{ order.eventName }}</h3>
+                    <p class="muted">
+                      {{ order.customerName }} • {{ order.contactEmail }}
+                    </p>
+                  </div>
+                  <div class="order-summary__meta">
+                    <span
+                      class="status-pill"
+                      [class]="'status-pill ' + statusClass(order.status)"
+                      >{{ order.status }}</span
+                    >
+                    <p class="muted">
+                      {{ order.startDate | date: 'mediumTime' }} →
+                      {{ order.endDate | date: 'mediumTime' }}
+                    </p>
+                    <p class="muted">{{ order.location }}</p>
+                  </div>
+                </button>
+                <div class="order-row__actions">
+                  <button
+                    type="button"
+                    class="ghost"
+                    (click)="updateStatus(order, 'Collected')"
+                    [disabled]="order.status === 'Collected' || order.status === 'Returned'"
+                  >
+                    Collected
+                  </button>
+                  <button
+                    type="button"
+                    class="ghost"
+                    (click)="printSalesOrder(order)"
+                  >
+                    Print sales order
+                  </button>
+                  <button
+                    type="button"
+                    class="ghost"
+                    (click)="printPickList(order)"
+                  >
+                    Print pick list
+                  </button>
+                </div>
+              </article>
+            </div>
+          </div>
+        </ng-container>
+      </section>
+
+      <div
+        class="modal-backdrop"
+        *ngIf="showOrderModal"
+        (click)="closeOrderModal()"
+      >
+        <div
+          class="modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="orderModalTitle"
+          (click)="$event.stopPropagation()"
         >
-          <header>
+          <header class="modal__header">
             <div>
-              <p class="eyebrow">{{ order.reference }}</p>
-              <h3>{{ order.eventName }}</h3>
+              <p class="eyebrow">Create order</p>
+              <h2 id="orderModalTitle">Build a PartyHire sales order</h2>
+            </div>
+            <button
+              type="button"
+              class="modal__close"
+              aria-label="Close order form"
+              (click)="closeOrderModal()"
+            >
+              ×
+            </button>
+          </header>
+          <form class="modal__form" [formGroup]="orderForm" (ngSubmit)="submitOrder()">
+            <div class="form-grid">
+              <label>
+                <span>Customer / company</span>
+                <input
+                  type="text"
+                  formControlName="customerName"
+                  placeholder="Client name"
+                />
+              </label>
+              <label>
+                <span>Contact email</span>
+                <input
+                  type="email"
+                  formControlName="contactEmail"
+                  placeholder="ops@example.com"
+                />
+              </label>
+              <label>
+                <span>Contact phone</span>
+                <input
+                  type="tel"
+                  formControlName="contactPhone"
+                  placeholder="+64..."
+                />
+              </label>
+              <label>
+                <span>Event name</span>
+                <input
+                  type="text"
+                  formControlName="eventName"
+                  placeholder="Birthday, Wedding..."
+                />
+              </label>
+              <label>
+                <span>Start</span>
+                <input type="datetime-local" formControlName="startDate" />
+              </label>
+              <label>
+                <span>Return</span>
+                <input type="datetime-local" formControlName="endDate" />
+              </label>
+              <label>
+                <span>Location</span>
+                <input
+                  type="text"
+                  formControlName="location"
+                  placeholder="Venue / address"
+                />
+              </label>
+              <label>
+                <span>Delivery method</span>
+                <select formControlName="deliveryMethod">
+                  <option value="pickup">Pickup</option>
+                  <option value="delivery">Delivery</option>
+                </select>
+              </label>
+              <label class="full-width">
+                <span>Calendar recipients (comma separated)</span>
+                <input
+                  type="text"
+                  formControlName="recipients"
+                  placeholder="team@company.com, crew@company.com"
+                />
+              </label>
+              <label class="full-width">
+                <span>Notes for invoice / crew</span>
+                <textarea
+                  formControlName="notes"
+                  rows="2"
+                  placeholder="Access times, parking, delivery instructions"
+                ></textarea>
+              </label>
+            </div>
+
+            <div class="item-form" formArrayName="items">
+              <p class="eyebrow">Products</p>
+              <div
+                class="item-row"
+                *ngFor="
+                  let item of itemsArray.controls;
+                  let i = index;
+                  trackBy: trackByControl
+                "
+                [formGroupName]="i"
+              >
+                <div class="item-search">
+                  <label>Search product</label>
+                  <input
+                    type="search"
+                    formControlName="searchTerm"
+                    placeholder="Type to search products"
+                    (input)="itemsArray.at(i).get('stockId')?.setValue(null)"
+                  />
+                  <div class="suggestions" *ngIf="filteredInventory(i).length">
+                    <button
+                      type="button"
+                      class="suggestion"
+                      *ngFor="let stock of filteredInventory(i) | slice: 0:5"
+                      (click)="selectStock(i, stock)"
+                    >
+                      <span class="suggestion__name">{{ stock.name }}</span>
+                      <span class="suggestion__meta">{{ stock.category }}</span>
+                    </button>
+                  </div>
+                </div>
+
+                <label>
+                  <span>Qty</span>
+                  <input
+                    type="number"
+                    formControlName="quantity"
+                    min="1"
+                    placeholder="0"
+                  />
+                </label>
+
+                <button
+                  type="button"
+                  class="ghost"
+                  (click)="removeItemRow(i)"
+                  [disabled]="itemsArray.length === 1"
+                >
+                  Remove
+                </button>
+              </div>
+
+              <button type="button" class="ghost" (click)="addItemRow()">
+                + Add another item
+              </button>
+            </div>
+
+            <div class="actions">
+              <button type="submit" class="primary">Create sales order</button>
+              <button type="button" class="ghost" (click)="closeOrderModal()">
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div
+        class="modal-backdrop"
+        *ngIf="activeOrder"
+        (click)="closeOrderDetail()"
+      >
+        <div
+          class="modal modal--wide"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="orderDetailTitle"
+          (click)="$event.stopPropagation()"
+        >
+          <header class="modal__header">
+            <div>
+              <p class="eyebrow">{{ activeOrder!.reference }}</p>
+              <h2 id="orderDetailTitle">{{ activeOrder!.eventName }}</h2>
               <p class="muted">
-                {{ order.customerName }} • {{ order.contactEmail }}
+                {{ activeOrder!.customerName }} • {{ activeOrder!.contactEmail }}
               </p>
             </div>
-            <div class="order-meta">
+            <div class="modal__header-actions">
               <span
                 class="status-pill"
-                [class]="'status-pill ' + statusClass(order.status)"
-                >{{ order.status }}</span
+                [class]="'status-pill ' + statusClass(activeOrder!.status)"
+                >{{ activeOrder!.status }}</span
               >
-              <div class="doc-numbers">
-                <span>Quote: {{ order.quoteNumber }}</span>
-                <span>Invoice: {{ order.invoiceNumber }}</span>
-              </div>
+              <button
+                type="button"
+                class="modal__close"
+                aria-label="Close order"
+                (click)="closeOrderDetail()"
+              >
+                ×
+              </button>
             </div>
           </header>
 
-          <div class="order-body">
-            <div class="order-details">
-              <h4>Schedule & logistics</h4>
-              <p>
-                <strong>Start:</strong> {{ order.startDate | date: "medium" }}
-              </p>
-              <p>
-                <strong>Return:</strong> {{ order.endDate | date: "medium" }}
-              </p>
-              <p><strong>Location:</strong> {{ order.location }}</p>
-              <p>
-                <strong>Delivery:</strong>
-                {{ order.deliveryMethod | titlecase }}
-              </p>
-              <p *ngIf="order.notes">
-                <strong>Notes:</strong> {{ order.notes }}
-              </p>
-              <div class="calendar-block">
-                <p class="muted">Google Calendar template:</p>
-                <a
-                  [href]="order.calendarEvent.googleCalendarUrl"
-                  target="_blank"
-                  rel="noreferrer"
-                  >Add to calendar</a
-                >
+          <div class="order-detail">
+            <div class="order-detail__meta">
+              <div>
+                <p class="eyebrow">Schedule</p>
+                <p>
+                  {{ activeOrder!.startDate | date: 'medium' }} →
+                  {{ activeOrder!.endDate | date: 'medium' }}
+                </p>
+              </div>
+              <div>
+                <p class="eyebrow">Location</p>
+                <p>{{ activeOrder!.location }}</p>
+              </div>
+              <div>
+                <p class="eyebrow">Delivery</p>
+                <p>{{ activeOrder!.deliveryMethod | titlecase }}</p>
+              </div>
+              <div>
+                <p class="eyebrow">Quote / Invoice</p>
+                <p>
+                  Quote {{ activeOrder!.quoteNumber }} • Invoice
+                  {{ activeOrder!.invoiceNumber }}
+                </p>
+              </div>
+            </div>
+
+            <div class="calendar-block">
+              <div>
+                <p class="eyebrow">Calendar</p>
                 <p class="muted">
                   Attendees:
                   {{
-                    order.calendarEvent.attendees.join(", ") || "None listed"
+                    activeOrder!.calendarEvent.attendees.join(', ') ||
+                      'None listed'
                   }}
                 </p>
               </div>
+              <a
+                class="primary"
+                [href]="activeOrder!.calendarEvent.googleCalendarUrl"
+                target="_blank"
+                rel="noreferrer"
+                >Add to calendar</a
+              >
             </div>
 
             <div class="order-items">
@@ -288,7 +381,7 @@
                 <span>Unit</span>
                 <span>Total</span>
               </div>
-              <div class="table-row" *ngFor="let item of order.items">
+              <div class="table-row" *ngFor="let item of activeOrder!.items">
                 <span>{{ item.name }}</span>
                 <span>{{ item.quantity }}</span>
                 <span>{{ item.unitPrice | currency }}</span>
@@ -298,87 +391,84 @@
                 <span>Subtotal</span>
                 <span></span>
                 <span></span>
-                <span>{{ order.totals.subtotal | currency }}</span>
+                <span>{{ activeOrder!.totals.subtotal | currency }}</span>
               </div>
               <div class="table-row">
                 <span>GST (15%)</span>
                 <span></span>
                 <span></span>
-                <span>{{ order.totals.gst | currency }}</span>
+                <span>{{ activeOrder!.totals.gst | currency }}</span>
               </div>
               <div class="table-row grand-total">
                 <span>Order total</span>
                 <span></span>
                 <span></span>
-                <span>{{ order.totals.total | currency }}</span>
+                <span>{{ activeOrder!.totals.total | currency }}</span>
+              </div>
+            </div>
+
+            <div class="order-detail__footer">
+              <div class="returns">
+                <p class="eyebrow">Returns & reconciliation</p>
+                <p class="muted">
+                  Status updates automatically when you save reconciliation. Predicted
+                  status: {{ computedReturnStatus(activeOrder!) }}.
+                </p>
+                <div class="return-grid">
+                  <label *ngFor="let item of activeOrder!.items">
+                    <span>{{ item.name }} (out: {{ item.quantity }})</span>
+                    <input
+                      type="number"
+                      min="0"
+                      [max]="item.quantity"
+                      [ngModel]="returnSheets[activeOrder!.id][item.stockId]"
+                      (ngModelChange)="
+                        setReturnedQuantity(activeOrder!.id, item.stockId, $event)
+                      "
+                      name="return-{{ activeOrder!.id }}-{{ item.stockId }}"
+                    />
+                  </label>
+                </div>
+                <div class="button-group">
+                  <button
+                    type="button"
+                    class="primary"
+                    (click)="saveReconciliation(activeOrder!)"
+                  >
+                    Save reconciliation
+                  </button>
+                </div>
+              </div>
+
+              <div class="order-detail__actions">
+                <button
+                  type="button"
+                  class="ghost"
+                  (click)="regenerateCalendar(activeOrder!)"
+                >
+                  Resend calendar invite
+                </button>
+                <div class="button-group">
+                  <button
+                    type="button"
+                    class="ghost"
+                    (click)="printPickList(activeOrder!)"
+                  >
+                    Print pick list
+                  </button>
+                  <button
+                    type="button"
+                    class="primary"
+                    (click)="printSalesOrder(activeOrder!)"
+                  >
+                    Print sales order
+                  </button>
+                </div>
               </div>
             </div>
           </div>
-
-          <div class="order-footer">
-            <div class="status-actions">
-              <p class="eyebrow">Status</p>
-              <div class="button-group">
-                <button
-                  *ngFor="let status of statusOptions"
-                  type="button"
-                  [class.primary]="order.status === status"
-                  (click)="updateStatus(order, status)"
-                >
-                  {{ status }}
-                </button>
-              </div>
-            </div>
-
-            <div class="returns">
-              <p class="eyebrow">Returns & reconciliation</p>
-              <div class="return-grid">
-                <label *ngFor="let item of order.items">
-                  <span>{{ item.name }} (out: {{ item.quantity }})</span>
-                  <input
-                    type="number"
-                    min="0"
-                    [max]="item.quantity"
-                    [(ngModel)]="returnSheets[order.id][item.stockId]"
-                    name="return-{{ order.id }}-{{ item.stockId }}"
-                  />
-                </label>
-              </div>
-              <div class="button-group">
-                <button
-                  type="button"
-                  class="primary"
-                  (click)="applyReturnStatus(order, 'Returned')"
-                >
-                  Mark as returned
-                </button>
-                <button
-                  type="button"
-                  (click)="applyReturnStatus(order, 'Partial Return')"
-                >
-                  Save partial return
-                </button>
-                <button type="button" (click)="updateStatus(order, 'Missing')">
-                  Mark missing
-                </button>
-              </div>
-            </div>
-
-            <div class="actions">
-              <button
-                type="button"
-                class="ghost"
-                (click)="regenerateCalendar(order)"
-              >
-                Resend calendar invite
-              </button>
-              <button type="button" class="primary" (click)="printOrder(order)">
-                Print sales order
-              </button>
-            </div>
-          </div>
-        </article>
-      </section>
+        </div>
+      </div>
     </div>
   </content>
 </ui-shell>

--- a/src/app/partyhire/partyhire-component/partyhire.component.scss
+++ b/src/app/partyhire/partyhire-component/partyhire.component.scss
@@ -62,32 +62,89 @@
   }
 }
 
-.grid-layout {
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: 1rem;
-}
-
-.card {
-  background: $main-light-color;
-  border-radius: $major-border-radius;
-  padding: 1.5rem;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+.orders {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
-.card.secondary {
-  background: $hero-dark-color;
-  color: $hero-text-color;
-}
-
-.card-heading {
+.section-heading {
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.section-actions {
+  display: flex;
   align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.date-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.5rem 0;
+}
+
+.order-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid $main-border-color;
+  border-radius: $major-border-radius;
+  background: $main-light-color;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+}
+
+.order-summary {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.order-summary__meta {
+  text-align: right;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.order-row__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.empty {
+  padding: 1rem;
+  background: rgba($main-border-color, 0.4);
+  border-radius: $minor-border-radius;
+  color: rgba($main-text-color, 0.7);
 }
 
 .form-grid {
@@ -122,37 +179,58 @@ textarea {
   grid-column: span 2;
 }
 
-.items-section,
-.order-items,
-.return-grid {
-  background: rgba($main-border-color, 0.35);
-  border-radius: $minor-border-radius;
-  padding: 1rem;
-  border: 1px solid $main-border-color;
-}
-
-.section-heading {
+.item-form {
+  margin-top: 1rem;
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.helper {
-  color: rgba($main-text-color, 0.65);
-  margin-top: 0.15rem;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .item-row {
   display: grid;
-  grid-template-columns: 2fr 0.5fr 1fr auto;
-  align-items: center;
+  grid-template-columns: 1.4fr 0.5fr auto;
+  align-items: start;
   gap: 0.5rem;
   padding: 0.5rem 0;
 }
 
-.item-available small {
-  color: #475569;
+.item-search {
+  position: relative;
+}
+
+.suggestions {
+  display: grid;
+  gap: 0.25rem;
+  position: absolute;
+  background: $main-light-color;
+  border: 1px solid $main-border-color;
+  border-radius: $minor-border-radius;
+  width: 100%;
+  z-index: 2;
+  margin-top: 0.25rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.15);
+}
+
+.suggestion {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0.65rem;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba($accent-color, 0.08);
+  }
+}
+
+.suggestion__name {
+  font-weight: 700;
+}
+
+.suggestion__meta {
+  color: rgba($main-text-color, 0.7);
 }
 
 .button-group {
@@ -189,57 +267,6 @@ button {
   flex-wrap: wrap;
 }
 
-.stock-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-
-.stock-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.65rem 0.75rem;
-  background: rgba($hero-light-color, 0.1);
-  border-radius: $minor-border-radius;
-  border: 1px solid rgba($hero-light-color, 0.35);
-}
-
-.stock-name {
-  margin: 0;
-  font-weight: 700;
-}
-
-.stock-meta {
-  margin: 0;
-  color: rgba($hero-text-color, 0.75);
-}
-
-.stock-badges {
-  display: flex;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-}
-
-.pill {
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba($hero-text-color, 0.4);
-  background: rgba($hero-dark-color, 0.85);
-  color: $hero-text-color;
-
-  &.strong {
-    border-color: $success-text-light-color;
-    color: $success-text-light-color;
-  }
-}
-
-.info-panel {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
 .eyebrow {
   font-size: 0.85rem;
   text-transform: uppercase;
@@ -248,58 +275,113 @@ button {
   margin: 0;
 }
 
-.orders {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+.calendar-message {
+  background: rgba($accent-color, 0.12);
+  color: $accent-color;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba($accent-color, 0.3);
+  max-width: 320px;
 }
 
-.empty {
-  padding: 1rem;
-  background: rgba($main-border-color, 0.4);
-  border-radius: $minor-border-radius;
-  color: rgba($main-text-color, 0.7);
-}
-
-.order-card {
-  background: $main-light-color;
-  border-radius: $major-border-radius;
-  border: 1px solid $main-border-color;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.5rem;
-}
-
-.order-meta {
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.6);
   display: flex;
   align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 10;
+}
+
+.modal {
+  background: $main-light-color;
+  border-radius: $major-border-radius;
+  width: min(960px, 100%);
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.3);
+  padding: 1.25rem;
+}
+
+.modal--wide {
+  width: min(1100px, 100%);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.modal__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.modal__form {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
-.doc-numbers {
-  display: grid;
-  gap: 0.15rem;
-  color: rgba($main-text-color, 0.7);
+.order-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.order-body {
+.order-detail__meta {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid $main-border-color;
+  border-radius: $minor-border-radius;
+  background: rgba($main-border-color, 0.2);
+}
+
+.calendar-block {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 1rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: rgba($main-border-color, 0.6);
+  border: 1px solid $main-border-color;
+}
+
+.muted {
+  color: rgba($main-text-color, 0.6);
+  margin: 0.25rem 0;
 }
 
 .order-items {
   background: $hero-dark-color;
   color: $hero-text-color;
+  border-radius: $minor-border-radius;
+  overflow: hidden;
 }
 
 .table-head,
 .table-row {
   display: grid;
   grid-template-columns: 2fr 0.6fr 0.8fr 1fr;
-  padding: 0.35rem 0.25rem;
+  padding: 0.35rem 0.45rem;
 }
 
 .table-head {
@@ -317,9 +399,9 @@ button {
   color: $accent-color;
 }
 
-.order-footer {
+.order-detail__footer {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 1rem;
   align-items: start;
 }
@@ -334,41 +416,12 @@ button {
   width: 100%;
 }
 
-.calendar-block {
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
-  background: rgba($main-border-color, 0.6);
-  border: 1px solid $main-border-color;
-}
-
-.muted {
-  color: rgba($main-text-color, 0.6);
-  margin: 0.25rem 0;
-}
-
-.secondary .eyebrow,
-.secondary .stock-name,
-.secondary h3,
-.secondary h4 {
-  color: $hero-text-color;
-}
-
-.secondary p {
-  color: rgba($hero-text-color, 0.8);
-}
-
-.calendar-message {
-  background: rgba($accent-color, 0.12);
-  color: $accent-color;
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
-  border: 1px solid rgba($accent-color, 0.3);
-  max-width: 320px;
-}
-
-.orders .status-pill {
-  text-transform: none;
+.order-detail__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .sr-only {
@@ -380,26 +433,4 @@ button {
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   border: 0;
-}
-
-@media print {
-  .page-header,
-  .grid-layout,
-  .status-actions .button-group,
-  .actions,
-  .returns .button-group,
-  .calendar-message,
-  .orders > .section-heading,
-  .orders > .empty {
-    display: none !important;
-  }
-
-  .order-card {
-    page-break-after: always;
-    border: 1px solid #000;
-  }
-
-  .order-card:not(.print-ready) {
-    display: none !important;
-  }
 }

--- a/src/app/partyhire/partyhire-component/partyhire.component.ts
+++ b/src/app/partyhire/partyhire-component/partyhire.component.ts
@@ -16,6 +16,8 @@ import {
   PartyHireStockItem,
 } from './partyhire.models';
 import { PartyHireService } from './partyhire.service';
+import { OrgBrandingService } from '../../shared/org-branding/org-branding.service';
+import { AuthService } from '../../auth/auth.service';
 
 @Component({
   selector: 'partyhire-component',
@@ -34,27 +36,23 @@ import { PartyHireService } from './partyhire.service';
 export class PartyHireComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly partyHireService = inject(PartyHireService);
+  private readonly orgBrandingService = inject(OrgBrandingService);
+  private readonly authService = inject(AuthService);
 
   protected inventory: PartyHireStockItem[] = [];
   protected orders: PartyHireOrder[] = [];
-  protected selectedPrintId: string | null = null;
+  protected groupedOrders: {
+    date: string;
+    label: string;
+    orders: PartyHireOrder[];
+  }[] = [];
+  protected showOrderModal = false;
+  protected activeOrder: PartyHireOrder | null = null;
   protected calendarMessage = '';
   protected loading = false;
-  protected readonly statusOptions: PartyHireOrderStatus[] = [
-    'Prepped',
-    'Collected',
-    'Returned',
-    'Partial Return',
-    'Missing',
-  ];
-  protected readonly statusDescription: Record<PartyHireOrderStatus, string> = {
-    Draft: 'Draft',
-    Prepped: 'Prepped',
-    Collected: 'Collected',
-    Returned: 'Returned',
-    'Partial Return': 'Partial Return',
-    Missing: 'Missing',
-  };
+  protected showArchived = false;
+  protected orgName = 'Company Name';
+  protected orgLogoUrl: string | null = null;
 
   protected orderForm = this.fb.group({
     customerName: ['', Validators.required],
@@ -72,8 +70,8 @@ export class PartyHireComponent implements OnInit {
 
   protected returnSheets: Record<string, Record<number, number>> = {};
 
-  ngOnInit(): void {
-    void this.refreshData();
+  async ngOnInit(): Promise<void> {
+    await Promise.all([this.refreshData(), this.loadBranding()]);
   }
 
   protected get itemsArray(): FormArray {
@@ -89,14 +87,24 @@ export class PartyHireComponent implements OnInit {
     this.itemsArray.removeAt(index);
   }
 
-  protected availableStock(item: PartyHireStockItem): number {
-    return Math.max(0, item.total - item.allocated);
+  protected filteredInventory(index: number): PartyHireStockItem[] {
+    const searchTerm =
+      (this.itemsArray.at(index).get('searchTerm')?.value as string) ?? '';
+
+    if (!searchTerm.trim()) return this.inventory;
+
+    const term = searchTerm.toLowerCase();
+    return this.inventory.filter(
+      (item) =>
+        item.name.toLowerCase().includes(term) ||
+        item.category.toLowerCase().includes(term),
+    );
   }
 
-  protected remainingStock(stockId: number | null | undefined): number {
-    if (!stockId) return 0;
-    const stock = this.inventory.find((item) => item.id === stockId);
-    return stock ? this.availableStock(stock) : 0;
+  protected selectStock(index: number, stock: PartyHireStockItem): void {
+    const group = this.itemsArray.at(index);
+    group.get('stockId')?.setValue(stock.id);
+    group.get('searchTerm')?.setValue(stock.name);
   }
 
   protected async submitOrder(): Promise<void> {
@@ -138,8 +146,25 @@ export class PartyHireComponent implements OnInit {
     });
     this.itemsArray.push(this.buildItemGroup());
 
+    this.showOrderModal = false;
+
     await this.refreshData();
     this.initialiseReturnSheet(order);
+  }
+
+  protected openOrderModal(): void {
+    this.showOrderModal = true;
+  }
+
+  protected closeOrderModal(): void {
+    this.showOrderModal = false;
+    this.orderForm.reset({
+      deliveryMethod: 'pickup',
+      recipients: this.orderForm.value.recipients,
+      items: [],
+    });
+    this.itemsArray.clear();
+    this.itemsArray.push(this.buildItemGroup());
   }
 
   protected async updateStatus(
@@ -150,13 +175,25 @@ export class PartyHireComponent implements OnInit {
     await this.refreshData();
   }
 
-  protected async applyReturnStatus(
-    order: PartyHireOrder,
-    status: Extract<PartyHireOrderStatus, 'Returned' | 'Partial Return'>,
-  ): Promise<void> {
+  protected async saveReconciliation(order: PartyHireOrder): Promise<void> {
     const returned = this.returnSheets[order.id] ?? {};
-    await this.partyHireService.recordReturn(order.id, returned, status);
+    const fullyReturned = order.items.every(
+      (item) => (returned[item.stockId] ?? 0) >= item.quantity,
+    );
+    const newStatus: PartyHireOrderStatus = fullyReturned
+      ? 'Returned'
+      : 'Partial Return';
+
+    await this.partyHireService.recordReturn(order.id, returned, newStatus);
     await this.refreshData();
+
+    const updatedOrder = this.orders.find((o) => o.id === order.id) ?? null;
+    if (!this.showArchived && updatedOrder?.status === 'Returned') {
+      this.activeOrder = null;
+      return;
+    }
+
+    this.activeOrder = updatedOrder;
   }
 
   protected async regenerateCalendar(order: PartyHireOrder): Promise<void> {
@@ -166,9 +203,14 @@ export class PartyHireComponent implements OnInit {
       'A fresh calendar invite has been generated for this order.';
   }
 
-  protected printOrder(order: PartyHireOrder): void {
-    this.selectedPrintId = order.id;
-    setTimeout(() => window.print(), 50);
+  protected printSalesOrder(order: PartyHireOrder): void {
+    const documentBody = this.buildSalesOrderTemplate(order);
+    this.openPrintWindow(`Sales Order ${order.reference}`, documentBody);
+  }
+
+  protected printPickList(order: PartyHireOrder): void {
+    const documentBody = this.buildPickListTemplate(order);
+    this.openPrintWindow(`Pick List ${order.reference}`, documentBody);
   }
 
   protected trackByOrder(_index: number, order: PartyHireOrder): string {
@@ -188,9 +230,47 @@ export class PartyHireComponent implements OnInit {
     return status.toLowerCase().replaceAll(' ', '-');
   }
 
-  protected totalAllocated(stockId: number): number {
-    const stock = this.inventory.find((item) => item.id === stockId);
-    return stock?.allocated ?? 0;
+  protected toggleArchived(): void {
+    this.showArchived = !this.showArchived;
+    this.groupedOrders = this.buildGroupedOrders();
+
+    if (!this.showArchived && this.activeOrder?.status === 'Returned') {
+      this.activeOrder = null;
+    }
+  }
+
+  protected setReturnedQuantity(
+    orderId: string,
+    stockId: number,
+    value: string | number,
+  ): void {
+    const parsed = Math.max(0, Number(value) || 0);
+    this.returnSheets[orderId] = {
+      ...(this.returnSheets[orderId] ?? {}),
+      [stockId]: parsed,
+    };
+  }
+
+  protected computedReturnStatus(order: PartyHireOrder): PartyHireOrderStatus {
+    const returned = this.returnSheets[order.id] ?? {};
+    const fullyReturned = order.items.every(
+      (item) => (returned[item.stockId] ?? 0) >= item.quantity,
+    );
+    return fullyReturned ? 'Returned' : 'Partial Return';
+  }
+
+  private async loadBranding(): Promise<void> {
+    try {
+      const branding = await this.orgBrandingService.getBranding(
+        this.authService.orgSlug,
+      );
+      if (branding) {
+        this.orgName = branding.name;
+        this.orgLogoUrl = branding.logoUrl;
+      }
+    } catch (error) {
+      console.error('Failed to load branding', error);
+    }
   }
 
   private async refreshData(): Promise<void> {
@@ -200,7 +280,11 @@ export class PartyHireComponent implements OnInit {
       this.partyHireService.listOrders(),
     ]);
     this.inventory = inventory;
-    this.orders = orders;
+    this.orders = orders.sort(
+      (a, b) =>
+        new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+    );
+    this.groupedOrders = this.buildGroupedOrders();
     this.orders.forEach((order) => this.initialiseReturnSheet(order));
     this.loading = false;
   }
@@ -210,7 +294,7 @@ export class PartyHireComponent implements OnInit {
       this.returnSheets[order.id] = Object.fromEntries(
         order.items.map((item) => [
           item.stockId,
-          order.returnedItems?.[item.stockId] ?? item.quantity,
+          order.returnedItems?.[item.stockId] ?? item.returnedQuantity ?? 0,
         ]),
       );
     }
@@ -218,7 +302,8 @@ export class PartyHireComponent implements OnInit {
 
   private buildItemGroup() {
     return this.fb.group({
-      stockId: [this.inventory[0]?.id ?? null, Validators.required],
+      searchTerm: [''],
+      stockId: [null, Validators.required],
       quantity: [1, [Validators.required, Validators.min(1)]],
     });
   }
@@ -228,5 +313,201 @@ export class PartyHireComponent implements OnInit {
       .split(',')
       .map((entry) => entry.trim())
       .filter(Boolean);
+  }
+
+  private buildGroupedOrders(): {
+    date: string;
+    label: string;
+    orders: PartyHireOrder[];
+  }[] {
+    const dateMap = new Map<string, PartyHireOrder[]>();
+
+    this.orders
+      .filter((order) => this.showArchived || order.status !== 'Returned')
+      .forEach((order) => {
+      const dateKey = new Date(order.startDate).toDateString();
+      const group = dateMap.get(dateKey) ?? [];
+      group.push(order);
+      dateMap.set(dateKey, group);
+    });
+
+    const sortedKeys = Array.from(dateMap.keys()).sort((a, b) => {
+      const dateA = new Date(a).setHours(0, 0, 0, 0);
+      const dateB = new Date(b).setHours(0, 0, 0, 0);
+      return dateA - dateB;
+    });
+
+    const todayKey = new Date().toDateString();
+    const orderedKeys = [
+      ...sortedKeys.filter((key) => key === todayKey),
+      ...sortedKeys.filter((key) => key !== todayKey),
+    ];
+
+    return orderedKeys.map((key) => {
+      const date = new Date(key);
+      const label =
+        key === todayKey
+          ? 'Today'
+          : new Intl.DateTimeFormat('en-NZ', {
+              weekday: 'long',
+              month: 'short',
+              day: 'numeric',
+            }).format(date);
+
+      return {
+        date: key,
+        label,
+        orders: (dateMap.get(key) ?? []).sort(
+          (a, b) =>
+            new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+        ),
+      };
+    });
+  }
+
+  protected openOrderDetail(order: PartyHireOrder): void {
+    this.activeOrder = order;
+    this.initialiseReturnSheet(order);
+  }
+
+  protected closeOrderDetail(): void {
+    this.activeOrder = null;
+  }
+
+  private openPrintWindow(title: string, body: string): void {
+    const printWindow = window.open('', '_blank', 'width=900,height=1200');
+    if (!printWindow) return;
+
+    printWindow.document.write(`<!doctype html><html><head><title>${title}</title>
+      <style>
+        body { font-family: 'Inter', system-ui, -apple-system, sans-serif; margin: 0; padding: 1.5rem; color: #0f172a; }
+        h1, h2, h3, h4 { margin: 0 0 0.35rem 0; }
+        .header { display: flex; justify-content: space-between; align-items: center; border-bottom: 2px solid #0f172a; padding-bottom: 0.75rem; margin-bottom: 1rem; gap: 1rem; }
+        .brand { display: flex; align-items: center; gap: 0.75rem; }
+        .brand__logo { max-height: 54px; max-width: 160px; object-fit: contain; }
+        .brand__fallback { font-weight: 700; font-size: 1.1rem; color: #0f172a; }
+        .pill { display: inline-flex; padding: 0.25rem 0.75rem; border-radius: 999px; background: #0ea5e9; color: #0b1726; font-weight: 600; }
+        .meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 0.5rem; margin-bottom: 1rem; }
+        .meta strong { display: block; color: #0f172a; margin-bottom: 0.15rem; }
+        table { width: 100%; border-collapse: collapse; margin-top: 0.75rem; }
+        th, td { text-align: left; padding: 0.55rem; border-bottom: 1px solid #e2e8f0; }
+        th { background: #0f172a; color: #e2e8f0; }
+        .total-row { font-weight: 700; }
+        .accent { color: #0ea5e9; }
+        .checkbox-cell { width: 36px; text-align: center; }
+        .checkbox-box { width: 18px; height: 18px; border: 2px solid #0f172a; display: inline-block; border-radius: 4px; }
+      </style>
+    </head><body>${body}</body></html>`);
+    printWindow.document.close();
+    printWindow.focus();
+    setTimeout(() => {
+      printWindow.print();
+      printWindow.close();
+    }, 200);
+  }
+
+  private buildSalesOrderTemplate(order: PartyHireOrder): string {
+    const items = order.items
+      .map(
+        (item) => `
+          <tr>
+            <td>${item.name}</td>
+            <td>${item.quantity}</td>
+            <td>${item.unitPrice.toFixed(2)}</td>
+            <td>${(item.quantity * item.unitPrice).toFixed(2)}</td>
+          </tr>`,
+      )
+      .join('');
+
+    return `
+      <div class="header">
+        <div class="brand">
+          ${
+            this.orgLogoUrl
+              ? `<img class="brand__logo" src="${this.orgLogoUrl}" alt="${this.orgName} logo" />`
+              : `<span class="brand__fallback">${this.orgName}</span>`
+          }
+        </div>
+        <div>
+          <p class="pill">${order.status}</p>
+          <h1>Sales order ${order.reference}</h1>
+          <p class="accent">Quote ${order.quoteNumber} • Invoice ${order.invoiceNumber}</p>
+        </div>
+        <div>
+          <strong>${order.eventName}</strong><br />
+          ${new Date(order.startDate).toLocaleString()} - ${new Date(
+            order.endDate,
+          ).toLocaleString()}
+        </div>
+      </div>
+      <div class="meta">
+        <div><strong>Customer</strong>${order.customerName}</div>
+        <div><strong>Contact</strong>${order.contactEmail} • ${order.contactPhone}</div>
+        <div><strong>Location</strong>${order.location}</div>
+        <div><strong>Delivery</strong>${order.deliveryMethod}</div>
+        <div><strong>Notes</strong>${order.notes || '—'}</div>
+      </div>
+      <table>
+        <thead>
+          <tr><th>Item</th><th>Qty</th><th>Unit price</th><th>Line total</th></tr>
+        </thead>
+        <tbody>${items}</tbody>
+        <tfoot>
+          <tr class="total-row"><td colspan="3">Subtotal</td><td>${order.totals.subtotal.toFixed(2)}</td></tr>
+          <tr class="total-row"><td colspan="3">GST (15%)</td><td>${order.totals.gst.toFixed(2)}</td></tr>
+          <tr class="total-row"><td colspan="3">Total</td><td>${order.totals.total.toFixed(2)}</td></tr>
+        </tfoot>
+      </table>
+    `;
+  }
+
+  private buildPickListTemplate(order: PartyHireOrder): string {
+    const items = order.items
+      .map(
+        (item) => `
+          <tr>
+            <td class="checkbox-cell"><span class="checkbox-box"></span></td>
+            <td>${item.quantity}</td>
+            <td>${item.name}</td>
+            <td>${this.lookupSku(item.stockId)}</td>
+          </tr>`,
+      )
+      .join('');
+
+    return `
+      <div class="header">
+        <div class="brand">
+          ${
+            this.orgLogoUrl
+              ? `<img class="brand__logo" src="${this.orgLogoUrl}" alt="${this.orgName} logo" />`
+              : `<span class="brand__fallback">${this.orgName}</span>`
+          }
+        </div>
+        <div>
+          <p class="pill">Pick list</p>
+          <h1>${order.eventName}</h1>
+          <p class="accent">${order.reference} • ${order.customerName}</p>
+        </div>
+        <div>
+          <strong>Pack by</strong><br />${new Date(order.startDate).toLocaleString()}
+        </div>
+      </div>
+      <div class="meta">
+        <div><strong>Location</strong>${order.location}</div>
+        <div><strong>Delivery</strong>${order.deliveryMethod}</div>
+        <div><strong>Contact</strong>${order.contactEmail} • ${order.contactPhone}</div>
+      </div>
+      <table>
+        <thead>
+          <tr><th class="checkbox-cell"></th><th>Qty</th><th>Item</th><th>SKU</th></tr>
+        </thead>
+        <tbody>${items}</tbody>
+      </table>
+    `;
+  }
+
+  private lookupSku(stockId: number): string {
+    const item = this.inventory.find((stock) => stock.id === stockId);
+    return item?.sku || '—';
   }
 }


### PR DESCRIPTION
## Summary
- add archived toggle with collected inline action and automatic return-based status updates
- include company branding on print layouts and update pick lists to checkbox/sku-focused format
- improve reconciliation inputs per item and hide returned orders from active view

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692140cb2b588323b9deec8fdc3f9c5b)