### PR TITLE
Add inventory detail and availability views

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -67,6 +67,24 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'inventory/:sku/availability',
+    loadComponent: () =>
+      import(
+        './inventory/inventory-availability/inventory-availability.component'
+      ).then((m) => m.InventoryAvailabilityComponent),
+    title: 'Inventory availability | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
+    path: 'inventory/:sku',
+    loadComponent: () =>
+      import(
+        './inventory/inventory-item-detail/inventory-item-detail.component'
+      ).then((m) => m.InventoryItemDetailComponent),
+    title: 'Inventory detail | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
     path: 'inventory',
     loadComponent: () =>
       import('./inventory/inventory-component/inventory-component').then(

--- a/src/app/inventory/inventory-availability/inventory-availability.component.html
+++ b/src/app/inventory/inventory-availability/inventory-availability.component.html
@@ -1,0 +1,74 @@
+<ui-shell>
+  <content class="availability-page" *ngIf="item; else missing">
+    <nav class="breadcrumbs">
+      <a routerLink="/inventory">Inventory</a>
+      <span>/</span>
+      <a [routerLink]="['/inventory', item?.sku]">{{ item?.sku }}</a>
+      <span>/</span>
+      <span>Availability</span>
+    </nav>
+
+    <header class="page-header">
+      <div>
+        <p class="eyebrow">Timeline</p>
+        <h1>{{ item?.name }}</h1>
+        <p class="muted">Track bookings by sales order and quantity</p>
+      </div>
+      <a class="secondary" [routerLink]="['/inventory', item?.sku]">Back to item</a>
+    </header>
+
+    <section class="card">
+      <div class="card-header">
+        <div>
+          <p class="eyebrow">Bookings</p>
+          <h3>Upcoming allocations</h3>
+        </div>
+        <p class="muted" *ngIf="rangeStart && rangeEnd">
+          {{ rangeStart | date: 'mediumDate' }} — {{ rangeEnd | date: 'mediumDate' }}
+        </p>
+      </div>
+
+      <div class="timeline" *ngIf="bookings.length; else noBookings">
+        <div class="timeline-bar" *ngFor="let booking of bookings" [ngStyle]="barStyle(booking)">
+          <span class="label">{{ booking.orderId }} · {{ booking.quantity }} pcs</span>
+        </div>
+      </div>
+
+      <ng-template #noBookings>
+        <p class="muted">No bookings for this item yet.</p>
+      </ng-template>
+    </section>
+
+    <section class="card" *ngIf="bookings.length">
+      <table>
+        <thead>
+          <tr>
+            <th>Order</th>
+            <th>Type</th>
+            <th>From</th>
+            <th>To</th>
+            <th>Quantity</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let booking of bookings">
+            <td>{{ booking.orderId }}</td>
+            <td>{{ booking.type | titlecase }}</td>
+            <td>{{ booking.startDate | date: 'mediumDate' }}</td>
+            <td>{{ booking.endDate | date: 'mediumDate' }}</td>
+            <td>{{ booking.quantity }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </content>
+</ui-shell>
+
+<ng-template #missing>
+  <ui-shell>
+    <content class="availability-page">
+      <p class="muted">Item not found.</p>
+      <a routerLink="/inventory" class="primary">Back to inventory</a>
+    </content>
+  </ui-shell>
+</ng-template>

--- a/src/app/inventory/inventory-availability/inventory-availability.component.scss
+++ b/src/app/inventory/inventory-availability/inventory-availability.component.scss
@@ -1,0 +1,108 @@
+@use "../../../style/buttons.scss" as *;
+
+.availability-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #6b7280;
+
+  a {
+    color: #2563eb;
+    text-decoration: none;
+  }
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 1rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.05);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+  margin: 0;
+}
+
+.muted {
+  color: #6b7280;
+  margin: 0;
+}
+
+.timeline {
+  position: relative;
+  height: 120px;
+  background: #f8fafc;
+  border-radius: 10px;
+  border: 1px dashed #cbd5e1;
+  overflow: hidden;
+}
+
+.timeline-bar {
+  position: absolute;
+  top: 20px;
+  height: 60px;
+  background: linear-gradient(90deg, #2563eb, #38bdf8);
+  border-radius: 12px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  box-shadow: 0 6px 12px rgba(37, 99, 235, 0.25);
+}
+
+.timeline-bar .label {
+  margin: 0;
+  font-weight: 700;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+th {
+  background: #f8fafc;
+  font-weight: 700;
+}
+
+a.primary,
+button.primary {
+  @include primary-button;
+}
+
+a.secondary,
+button.secondary {
+  @include secondary-button;
+}

--- a/src/app/inventory/inventory-availability/inventory-availability.component.ts
+++ b/src/app/inventory/inventory-availability/inventory-availability.component.ts
@@ -1,0 +1,59 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+import { InventoryItem, ItemBooking } from '../../shared/models-and-mappers/item/item-model';
+import { InventoryService } from '../inventory.service';
+
+@Component({
+  selector: 'inventory-availability',
+  standalone: true,
+  imports: [CommonModule, DatePipe, RouterLink, UiShellComponent],
+  templateUrl: './inventory-availability.component.html',
+  styleUrl: './inventory-availability.component.scss',
+})
+export class InventoryAvailabilityComponent implements OnInit {
+  item?: InventoryItem;
+  bookings: ItemBooking[] = [];
+  rangeStart?: Date;
+  rangeEnd?: Date;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly inventoryService: InventoryService,
+  ) {}
+
+  ngOnInit(): void {
+    const sku = this.route.snapshot.paramMap.get('sku');
+    if (!sku) return;
+
+    this.item = this.inventoryService.getBySku(sku);
+    this.bookings = this.item?.availabilityBookings ?? [];
+    this.computeRange();
+  }
+
+  computeRange() {
+    if (!this.bookings.length) return;
+    const starts = this.bookings.map((b) => new Date(b.startDate));
+    const ends = this.bookings.map((b) => new Date(b.endDate));
+    this.rangeStart = new Date(Math.min(...starts.map((d) => d.getTime())));
+    this.rangeEnd = new Date(Math.max(...ends.map((d) => d.getTime())));
+  }
+
+  barStyle(booking: ItemBooking): Record<string, string> {
+    if (!this.rangeStart || !this.rangeEnd) return {};
+    const totalMs = this.rangeEnd.getTime() - this.rangeStart.getTime();
+    const startOffset = new Date(booking.startDate).getTime() -
+      this.rangeStart.getTime();
+    const durationMs = Math.max(
+      new Date(booking.endDate).getTime() -
+        new Date(booking.startDate).getTime(),
+      24 * 60 * 60 * 1000,
+    );
+    const total = totalMs || 1;
+    return {
+      left: `${(startOffset / total) * 100}%`,
+      width: `${(durationMs / total) * 100}%`,
+    };
+  }
+}

--- a/src/app/inventory/inventory-component/inventory-component.html
+++ b/src/app/inventory/inventory-component/inventory-component.html
@@ -1,68 +1,240 @@
 <ui-shell>
-  <content>
-    <h1>Inventory</h1>
+  <content class="inventory-content">
+    <div class="inventory-header">
+      <div>
+        <p class="eyebrow">Operations</p>
+        <h1>Inventory</h1>
+        <p class="subtitle">
+          Manage stock across warehouses, create new SKUs, and drill into item detail.
+        </p>
+      </div>
+      <button class="primary" type="button" (click)="openNewItemDialog()">
+        + Add inventory item
+      </button>
+    </div>
 
-    <table>
-      <thead>
-        <tr>
-          <th>
-            <input
-              type="checkbox"
-              [checked]="isAllSelected()"
-              (change)="toggleSelectAll($event)"
-            />
-          </th>
-          <th (click)="sortData('id')">
-            ID
-            <span *ngIf="sortColumn === 'id'">{{
-              sortDirection === "asc" ? "▲" : "▼"
-            }}</span>
-          </th>
-          <th (click)="sortData('name')">
-            Name
-            <span *ngIf="sortColumn === 'name'">{{
-              sortDirection === "asc" ? "▲" : "▼"
-            }}</span>
-          </th>
-          <th (click)="sortData('category')">
-            Category
-            <span *ngIf="sortColumn === 'category'">{{
-              sortDirection === "asc" ? "▲" : "▼"
-            }}</span>
-          </th>
-          <th (click)="sortData('stock')">
-            Stock
-            <span *ngIf="sortColumn === 'stock'">{{
-              sortDirection === "asc" ? "▲" : "▼"
-            }}</span>
-          </th>
-          <th (click)="sortData('price')">
-            Price
-            <span *ngIf="sortColumn === 'price'">{{
-              sortDirection === "asc" ? "▲" : "▼"
-            }}</span>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let item of sortedItems">
-          <td>
-            <input
-              type="checkbox"
-              [checked]="isSelected(item.id)"
-              (change)="toggleSelection(item.id)"
-            />
-          </td>
-          <td>{{ item.id }}</td>
-          <td>{{ item.name }}</td>
-          <td>{{ item.category }}</td>
-          <td>{{ item.stock }}</td>
-          <td>{{ item.price | currency }}</td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="table-wrapper" *ngIf="sortedItems.length; else emptyState">
+      <table>
+        <thead>
+          <tr>
+            <th (click)="sortData('sku')">
+              SKU
+              <span *ngIf="sortColumn === 'sku'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th (click)="sortData('name')">
+              Item name
+              <span *ngIf="sortColumn === 'name'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th (click)="sortData('category')">
+              Category
+              <span *ngIf="sortColumn === 'category'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th (click)="sortData('quantity')">
+              Quantity
+              <span *ngIf="sortColumn === 'quantity'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th (click)="sortData('quantityAvailable')">
+              Quantity available
+              <span *ngIf="sortColumn === 'quantityAvailable'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th (click)="sortData('unitDayRate')">
+              Unit day rate
+              <span *ngIf="sortColumn === 'unitDayRate'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th (click)="sortData('itemType')">
+              Item type
+              <span *ngIf="sortColumn === 'itemType'">{{ sortDirection === 'asc' ? '▲' : '▼' }}</span>
+            </th>
+            <th>Warehouses</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let item of sortedItems" [routerLink]="['/inventory', item.sku]" class="row-link">
+            <td>{{ item.sku }}</td>
+            <td>
+              <div class="cell-title">{{ item.name }}</div>
+              <div class="cell-meta">{{ item.itemMode }}</div>
+            </td>
+            <td>{{ item.category }}</td>
+            <td>{{ item.quantity }}</td>
+            <td>{{ item.quantityAvailable }}</td>
+            <td>{{ item.unitDayRate | currency }}</td>
+            <td class="badge" [class.sales]="item.itemType === 'sales'" [class.rental]="item.itemType === 'rental'" [class.consumable]="item.itemType === 'consumable'">
+              {{ item.itemType }}
+            </td>
+            <td>
+              <ul class="warehouse-list">
+                <li *ngFor="let allocation of item.warehouseQuantities">
+                  <span class="warehouse-name">{{ allocation.warehouse }}</span>
+                  <span class="warehouse-qty">{{ allocation.quantity }}</span>
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-    <!-- Action Button -->
-    <button (click)="performActionOnSelected()">Run Action on Selected</button>
+    <ng-template #emptyState>
+      <div class="empty-state">
+        <h3>No inventory yet</h3>
+        <p>Start by adding your first SKU and assigning it to a warehouse.</p>
+        <button type="button" class="primary" (click)="openNewItemDialog()">Add an item</button>
+      </div>
+    </ng-template>
   </content>
+
+  <div class="dialog-backdrop" *ngIf="showNewItemDialog">
+    <div class="dialog">
+      <div class="dialog-header">
+        <div>
+          <p class="eyebrow">New item</p>
+          <h2>Create inventory item</h2>
+        </div>
+        <button class="ghost" type="button" (click)="closeDialog()">✕</button>
+      </div>
+
+      <form class="dialog-body" (ngSubmit)="submitNewItem()">
+        <div class="form-grid">
+          <label>
+            Item name
+            <input type="text" name="name" [(ngModel)]="newItem.name" required />
+          </label>
+          <label>
+            Category
+            <input type="text" name="category" [(ngModel)]="newItem.category" required />
+          </label>
+          <label>
+            Item type
+            <select name="itemType" [(ngModel)]="newItem.itemType">
+              <option value="sales">Sales</option>
+              <option value="rental">Rental</option>
+              <option value="consumable">Consumable</option>
+            </select>
+          </label>
+          <label>
+            Item mode
+            <select name="itemMode" [(ngModel)]="newItem.itemMode">
+              <option value="Bulk">Bulk</option>
+              <option value="Serialised">Serialised</option>
+            </select>
+          </label>
+          <label>
+            Unit day rate
+            <input type="number" min="0" name="unitDayRate" [(ngModel)]="newItem.unitDayRate" required />
+          </label>
+          <label>
+            3 day rate
+            <input type="number" min="0" name="threeDay" [(ngModel)]="newItem.pricing.threeDay" placeholder="Auto" />
+          </label>
+          <label>
+            Week rate
+            <input type="number" min="0" name="week" [(ngModel)]="newItem.pricing.week" placeholder="Auto" />
+          </label>
+          <label>
+            Product cost
+            <input type="number" min="0" name="productCost" [(ngModel)]="newItem.productCost" />
+          </label>
+          <label>
+            Subhire cost
+            <input type="number" min="0" name="subhireCost" [(ngModel)]="newItem.subhireCost" />
+          </label>
+          <label>
+            Weight (kg)
+            <input type="number" step="0.1" name="weightKg" [(ngModel)]="newItem.weightKg" />
+          </label>
+          <label>
+            Dimensions (mm)
+            <input type="text" name="dimensionsMm" [(ngModel)]="newItem.dimensionsMm" placeholder="L x W x H" />
+          </label>
+          <label>
+            Road case size
+            <select name="roadcaseSize" [(ngModel)]="newItem.roadcaseSize">
+              <option [ngValue]="undefined">Select a size</option>
+              <option value="400">400</option>
+              <option value="600">600</option>
+              <option value="800">800</option>
+              <option value="1200">1200</option>
+              <option value="1400">1400</option>
+              <option value="1600">1600</option>
+              <option value="1800">1800</option>
+              <option value="Cable or Small Item">Cable or Small Item</option>
+            </select>
+          </label>
+          <label>
+            Quantity per road case
+            <input type="number" min="0" name="roadcaseQuantity" [(ngModel)]="newItem.roadcaseQuantity" />
+          </label>
+          <label>
+            Last tested
+            <input type="date" name="lastTested" [(ngModel)]="newItem.lastTested" />
+          </label>
+          <label>
+            Next test due (months)
+            <select name="nextTestDueMonths" [(ngModel)]="newItem.nextTestDueMonths">
+              <option [ngValue]="3">3 months</option>
+              <option [ngValue]="6">6 months</option>
+              <option [ngValue]="12">12 months</option>
+              <option [ngValue]="24">24 months</option>
+            </select>
+          </label>
+          <label>
+            Accessories (comma separated)
+            <input type="text" name="accessories" [(ngModel)]="newItem.accessories" placeholder="Clamp, PSU, Cable" />
+          </label>
+          <label>
+            Accessory to (comma separated)
+            <input type="text" name="accessoryTo" [(ngModel)]="newItem.accessoryTo" placeholder="Lighting kit, Stage box" />
+          </label>
+        </div>
+
+        <div class="warehouse-panel">
+          <div class="panel-header">
+            <div>
+              <p class="eyebrow">Warehouses</p>
+              <h3>Assign quantities</h3>
+            </div>
+            <p class="muted">Use the dropdown to distribute stock across multiple warehouses.</p>
+          </div>
+          <div class="warehouse-grid">
+            <label>
+              Warehouse
+              <select name="warehouseSelection" [(ngModel)]="warehouseSelection">
+                <option *ngFor="let warehouse of warehouses" [value]="warehouse">{{ warehouse }}</option>
+              </select>
+            </label>
+            <label>
+              Quantity
+              <input type="number" min="1" name="warehouseQuantity" [(ngModel)]="warehouseQuantity" />
+            </label>
+            <button class="secondary" type="button" (click)="addWarehouseAllocation()">Add warehouse</button>
+          </div>
+
+          <ul class="allocation-list">
+            <li *ngFor="let allocation of allocationPreview">
+              <div>
+                <strong>{{ allocation.warehouse }}</strong>
+                <p class="muted">{{ allocation.quantity }} units</p>
+              </div>
+              <button
+                type="button"
+                class="ghost"
+                aria-label="Remove warehouse allocation"
+                (click)="removeWarehouseAllocation(allocation.warehouse)"
+                *ngIf="warehouseAllocations.length > 0"
+              >
+                Remove
+              </button>
+            </li>
+          </ul>
+          <p class="muted">Total quantity: {{ totalWarehouseQuantity(allocationPreview) }}</p>
+        </div>
+
+        <div class="dialog-footer">
+          <button class="ghost" type="button" (click)="closeDialog()">Cancel</button>
+          <button class="primary" type="submit">Save item</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </ui-shell>

--- a/src/app/inventory/inventory-component/inventory-component.scss
+++ b/src/app/inventory/inventory-component/inventory-component.scss
@@ -1,13 +1,42 @@
 @use "../../../style/buttons.scss" as *;
 
-#control {
+.inventory-content {
   display: flex;
-  flex-direction: row;
-  align-items: center;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.inventory-header {
+  display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  flex-wrap: wrap;
+  gap: 1rem;
+
+  h1 {
+    margin: 0.25rem 0 0.5rem;
+  }
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  margin: 0;
+  color: #6b7280;
+}
+
+.subtitle {
+  margin: 0;
+  color: #4b5563;
+}
+
+.table-wrapper {
   width: 100%;
-  height: 4rem;
+  overflow: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.05);
 }
 
 table {
@@ -18,15 +47,234 @@ table {
 th {
   cursor: pointer;
   user-select: none;
-  background: #f3f3f3;
+  background: #f8fafc;
+  text-align: left;
+  padding: 12px;
+  font-weight: 600;
+  color: #111827;
+  border-bottom: 1px solid #e5e7eb;
 }
 
-th,
+th:last-child,
+td:last-child {
+  width: 220px;
+}
+
 td {
-  padding: 8px;
-  border: 1px solid #ccc;
+  padding: 12px;
+  border-bottom: 1px solid #f1f5f9;
+  color: #111827;
 }
 
-tr:hover {
-  background-color: #f9f9f9;
+tr.row-link {
+  transition: background-color 0.15s ease, transform 0.15s ease;
+}
+
+tr.row-link:hover {
+  background: #f8fafc;
+  transform: translateY(-1px);
+}
+
+.cell-title {
+  font-weight: 600;
+}
+
+.cell-meta {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  text-transform: capitalize;
+  font-size: 0.85rem;
+  background: #e5e7eb;
+}
+
+.badge.sales {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badge.rental {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.badge.consumable {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.warehouse-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.warehouse-name {
+  font-weight: 600;
+}
+
+.warehouse-qty {
+  color: #4b5563;
+  margin-left: 0.35rem;
+}
+
+.empty-state {
+  padding: 3rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  text-align: center;
+  background: #f8fafc;
+  color: #334155;
+
+  h3 {
+    margin-top: 0;
+  }
+
+  p {
+    margin-bottom: 1rem;
+  }
+}
+
+.dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 20;
+}
+
+.dialog {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: min(1100px, 90vw);
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+input,
+select,
+textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+  color: #111827;
+  background: #fff;
+}
+
+textarea {
+  min-height: 90px;
+}
+
+.warehouse-panel {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f8fafc;
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.muted {
+  color: #6b7280;
+  margin: 0;
+}
+
+.warehouse-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+  margin-top: 1rem;
+}
+
+.allocation-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.allocation-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+button.primary {
+  @include primary-button;
+}
+
+button.secondary {
+  @include secondary-button;
+}
+
+button.ghost {
+  @include ghost-button;
+}
+
+button {
+  cursor: pointer;
+}
+
+.row-link {
+  cursor: pointer;
 }

--- a/src/app/inventory/inventory-component/inventory-component.ts
+++ b/src/app/inventory/inventory-component/inventory-component.ts
@@ -1,36 +1,78 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { Component } from '@angular/core';
-import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
-import { dbFunctionsService } from '../../shared/supabase-service/db_functions.service';
-import { Item } from '../../shared/models-and-mappers/item/item-model';
 import { CommonModule, CurrencyPipe } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+import {
+  InventoryItem,
+  ItemMode,
+  ItemType,
+  TestInterval,
+  WarehouseQuantity,
+} from '../../shared/models-and-mappers/item/item-model';
+import { InventoryService } from '../inventory.service';
+import { Subscription } from 'rxjs';
+
+interface NewItemForm {
+  name: string;
+  category: string;
+  unitDayRate: number;
+  itemType: ItemType;
+  itemMode: ItemMode;
+  pricing: { oneDay?: number; threeDay?: number; week?: number };
+  productCost: number;
+  subhireCost: number;
+  weightKg?: number;
+  dimensionsMm?: string;
+  roadcaseSize?: InventoryItem['roadcaseSize'];
+  roadcaseQuantity?: number;
+  lastTested?: string;
+  nextTestDueMonths?: TestInterval;
+  accessories?: string;
+  accessoryTo?: string;
+}
 
 @Component({
   selector: 'inventory-component',
-  imports: [UiShellComponent, CurrencyPipe, CommonModule],
+  standalone: true,
+  imports: [
+    UiShellComponent,
+    CurrencyPipe,
+    CommonModule,
+    FormsModule,
+    RouterLink,
+  ],
   templateUrl: './inventory-component.html',
   styleUrl: './inventory-component.scss',
 })
-export class InventoryComponent {
-  items: any = [];
+export class InventoryComponent implements OnInit, OnDestroy {
+  items: InventoryItem[] = [];
+  private subscriptions: Subscription[] = [];
 
-  constructor(private dbFunctions: dbFunctionsService) {}
-
-  async ngOnInit() {
-    await this.loadInventory();
-  }
-
-  async loadInventory() {
-    this.items = await this.dbFunctions.getItems();
-    console.log('Jobs loaded:', this.items);
-  }
-
-  selectedIds = new Set<number>();
-
-  sortColumn: keyof Item | '' = '';
+  sortColumn: keyof InventoryItem | '' = '';
   sortDirection: 'asc' | 'desc' = 'asc';
 
-  get sortedItems(): Item[] {
+  showNewItemDialog = false;
+  warehouses = ['Main Warehouse', 'Tour Prep', 'Festival Site', 'Dry Hire Counter'];
+  warehouseSelection = this.warehouses[0];
+  warehouseQuantity = 1;
+  warehouseAllocations: WarehouseQuantity[] = [];
+
+  newItem: NewItemForm = this.buildBlankForm();
+
+  constructor(private readonly inventoryService: InventoryService) {}
+
+  ngOnInit() {
+    this.subscriptions.push(
+      this.inventoryService.items$.subscribe((items) => (this.items = items)),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  get sortedItems(): InventoryItem[] {
     if (!this.sortColumn) return this.items;
 
     return [...this.items].sort((a, b) => {
@@ -47,7 +89,7 @@ export class InventoryComponent {
     });
   }
 
-  sortData(column: keyof Item) {
+  sortData(column: keyof InventoryItem) {
     if (this.sortColumn === column) {
       this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
     } else {
@@ -56,36 +98,123 @@ export class InventoryComponent {
     }
   }
 
-  isSelected(id: number): boolean {
-    return this.selectedIds.has(id);
+  openNewItemDialog() {
+    this.showNewItemDialog = true;
+    this.newItem = this.buildBlankForm();
+    this.warehouseAllocations = [];
+    this.warehouseSelection = this.warehouses[0];
+    this.warehouseQuantity = 1;
   }
 
-  toggleSelection(id: number) {
-    if (this.selectedIds.has(id)) {
-      this.selectedIds.delete(id);
-    } else {
-      this.selectedIds.add(id);
-    }
+  closeDialog() {
+    this.showNewItemDialog = false;
   }
 
-  isAllSelected(): boolean {
-    return this.selectedIds.size === this.items.length;
-  }
-
-  toggleSelectAll(event: Event) {
-    const checkbox = event.target as HTMLInputElement;
-    if (checkbox.checked) {
-      this.selectedIds = new Set(this.items.map((item: Item) => item.id));
-    } else {
-      this.selectedIds.clear();
-    }
-  }
-
-  performActionOnSelected() {
-    const selectedItems = this.items.filter((item: Item) =>
-      this.selectedIds.has(item.id),
+  addWarehouseAllocation() {
+    if (!this.warehouseSelection || this.warehouseQuantity <= 0) return;
+    const existing = this.warehouseAllocations.find(
+      (allocation) => allocation.warehouse === this.warehouseSelection,
     );
-    console.log('Performing action on:', selectedItems);
-    // TODO: Replace with actual action logic
+
+    if (existing) {
+      existing.quantity += this.warehouseQuantity;
+    } else {
+      this.warehouseAllocations = [
+        ...this.warehouseAllocations,
+        { warehouse: this.warehouseSelection, quantity: this.warehouseQuantity },
+      ];
+    }
+
+    this.warehouseQuantity = 1;
+  }
+
+  removeWarehouseAllocation(warehouse: string) {
+    this.warehouseAllocations = this.warehouseAllocations.filter(
+      (allocation) => allocation.warehouse !== warehouse,
+    );
+  }
+
+  submitNewItem() {
+    const allocation =
+      this.warehouseAllocations.length > 0
+        ? this.warehouseAllocations
+        : [{ warehouse: this.warehouseSelection, quantity: this.warehouseQuantity }];
+
+    const totalQuantity = allocation.reduce((sum, entry) => sum + entry.quantity, 0);
+    const pricing = {
+      oneDay: this.newItem.pricing.oneDay ?? this.newItem.unitDayRate,
+      threeDay:
+        this.newItem.pricing.threeDay ?? Math.round(this.newItem.unitDayRate * 2.5),
+      week: this.newItem.pricing.week ?? Math.round(this.newItem.unitDayRate * 4),
+    };
+
+    this.inventoryService.addItem({
+      name: this.newItem.name,
+      category: this.newItem.category,
+      quantity: totalQuantity,
+      quantityAvailable: totalQuantity,
+      unitDayRate: this.newItem.unitDayRate,
+      itemType: this.newItem.itemType,
+      itemMode: this.newItem.itemMode,
+      pricing,
+      productCost: this.newItem.productCost,
+      subhireCost: this.newItem.subhireCost,
+      weightKg: this.newItem.weightKg,
+      dimensionsMm: this.newItem.dimensionsMm,
+      roadcaseSize: this.newItem.roadcaseSize,
+      roadcaseQuantity: this.newItem.roadcaseQuantity,
+      lastTested: this.newItem.lastTested,
+      nextTestDueMonths: this.newItem.nextTestDueMonths,
+      accessories: this.parseCSV(this.newItem.accessories),
+      accessoryTo: this.parseCSV(this.newItem.accessoryTo),
+      relatedSalesOrders: [],
+      relatedRepairOrders: [],
+      relatedTransferOrders: [],
+      warehouseQuantities: allocation,
+      availabilityBookings: [],
+      imageUrl:
+        'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=600&q=80',
+    });
+
+    this.closeDialog();
+  }
+
+  get allocationPreview(): WarehouseQuantity[] {
+    return this.warehouseAllocations.length > 0
+      ? this.warehouseAllocations
+      : [{ warehouse: this.warehouseSelection, quantity: this.warehouseQuantity }];
+  }
+
+  totalWarehouseQuantity(warehouse: WarehouseQuantity[]): number {
+    return warehouse.reduce((sum, entry) => sum + entry.quantity, 0);
+  }
+
+  private buildBlankForm(): NewItemForm {
+    return {
+      name: '',
+      category: '',
+      unitDayRate: 0,
+      itemType: 'rental',
+      itemMode: 'Bulk',
+      pricing: {},
+      productCost: 0,
+      subhireCost: 0,
+      weightKg: undefined,
+      dimensionsMm: undefined,
+      roadcaseSize: undefined,
+      roadcaseQuantity: undefined,
+      lastTested: undefined,
+      nextTestDueMonths: 12,
+      accessories: undefined,
+      accessoryTo: undefined,
+    };
+  }
+
+  private parseCSV(value?: string): string[] {
+    if (!value) return [];
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
   }
 }

--- a/src/app/inventory/inventory-item-detail/inventory-item-detail.component.html
+++ b/src/app/inventory/inventory-item-detail/inventory-item-detail.component.html
@@ -1,0 +1,194 @@
+<ui-shell>
+  <content class="detail-page" *ngIf="item; else missing">
+    <nav class="breadcrumbs">
+      <a routerLink="/inventory">Inventory</a>
+      <span>/</span>
+      <span>{{ item?.sku }}</span>
+    </nav>
+
+    <header class="detail-header">
+      <div>
+        <p class="eyebrow">{{ item.itemType | titlecase }} · {{ item.itemMode }}</p>
+        <h1>{{ item.name }}</h1>
+        <p class="muted">SKU {{ item.sku }}</p>
+      </div>
+      <div class="actions">
+        <button class="secondary" type="button">Edit item</button>
+        <button class="primary" type="button" (click)="goToAvailability()">Availability</button>
+      </div>
+    </header>
+
+    <section class="summary">
+      <div class="card image-card">
+        <img [src]="item.imageUrl || 'https://placehold.co/640x360'" [alt]="item.name" />
+      </div>
+      <div class="card pricing-card">
+        <div class="card-header">
+          <p class="eyebrow">Pricing</p>
+          <div class="price-row">
+            <div>
+              <p class="label">1 day</p>
+              <p class="value">{{ item.pricing.oneDay | currency }}</p>
+            </div>
+            <div>
+              <p class="label">3 day</p>
+              <p class="value">{{ item.pricing.threeDay | currency }}</p>
+            </div>
+            <div>
+              <p class="label">Week</p>
+              <p class="value">{{ item.pricing.week | currency }}</p>
+            </div>
+          </div>
+        </div>
+        <div class="cost-grid">
+          <div>
+            <p class="label">Product cost</p>
+            <p class="value">{{ item.productCost | currency }}</p>
+          </div>
+          <div>
+            <p class="label">Subhire cost</p>
+            <p class="value">{{ item.subhireCost | currency }}</p>
+          </div>
+          <div>
+            <p class="label">Unit day rate</p>
+            <p class="value">{{ item.unitDayRate | currency }}</p>
+          </div>
+          <div>
+            <p class="label">Quantity available</p>
+            <p class="value">{{ item.quantityAvailable }} / {{ item.quantity }}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card">
+        <div class="card-header">
+          <p class="eyebrow">Orders</p>
+          <h3>Related activity</h3>
+        </div>
+        <div class="pill-row">
+          <div>
+            <p class="label">Sales orders</p>
+            <div class="pill-group">
+              <span class="pill" *ngFor="let order of item.relatedSalesOrders">{{ order }}</span>
+              <span class="muted" *ngIf="!item.relatedSalesOrders?.length">None yet</span>
+            </div>
+          </div>
+          <div>
+            <p class="label">Repair orders</p>
+            <div class="pill-group">
+              <span class="pill" *ngFor="let order of item.relatedRepairOrders">{{ order }}</span>
+              <span class="muted" *ngIf="!item.relatedRepairOrders?.length">None yet</span>
+            </div>
+          </div>
+          <div>
+            <p class="label">Transfer orders</p>
+            <div class="pill-group">
+              <span class="pill" *ngFor="let order of item.relatedTransferOrders">{{ order }}</span>
+              <span class="muted" *ngIf="!item.relatedTransferOrders?.length">None yet</span>
+            </div>
+          </div>
+        </div>
+        <button class="ghost" type="button">Edit item</button>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <p class="eyebrow">Testing</p>
+          <h3>Compliance</h3>
+        </div>
+        <div class="detail-grid">
+          <div>
+            <p class="label">Last tested</p>
+            <p class="value">{{ item.lastTested | date: 'mediumDate' }}</p>
+          </div>
+          <div>
+            <p class="label">Next test due</p>
+            <p class="value">{{ getNextTestDate(item) | date: 'mediumDate' }}</p>
+          </div>
+          <div>
+            <p class="label">Item type</p>
+            <p class="value">{{ item.itemMode }}</p>
+          </div>
+          <div>
+            <p class="label">Road case</p>
+            <p class="value">{{ item.roadcaseSize || 'Not set' }}</p>
+          </div>
+          <div>
+            <p class="label">Qty per road case</p>
+            <p class="value">{{ item.roadcaseQuantity || '—' }}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card">
+        <div class="card-header">
+          <p class="eyebrow">Warehouses</p>
+          <h3>Quantities</h3>
+        </div>
+        <ul class="warehouse-breakdown">
+          <li *ngFor="let allocation of item.warehouseQuantities">
+            <div>
+              <p class="label">{{ allocation.warehouse }}</p>
+              <p class="value">{{ allocation.quantity }} units</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <p class="eyebrow">Accessories</p>
+          <h3>Related products</h3>
+        </div>
+        <div class="detail-grid">
+          <div>
+            <p class="label">Accessory products</p>
+            <div class="pill-group">
+              <span class="pill" *ngFor="let accessory of item.accessories">{{ accessory }}</span>
+              <span class="muted" *ngIf="!item.accessories?.length">None linked</span>
+            </div>
+          </div>
+          <div>
+            <p class="label">Accessory to</p>
+            <div class="pill-group">
+              <span class="pill" *ngFor="let parent of item.accessoryTo">{{ parent }}</span>
+              <span class="muted" *ngIf="!item.accessoryTo?.length">Not yet assigned</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card">
+        <div class="detail-grid">
+          <div>
+            <p class="label">Weight</p>
+            <p class="value">{{ item.weightKg || '—' }} kg</p>
+          </div>
+          <div>
+            <p class="label">Dimensions</p>
+            <p class="value">{{ item.dimensionsMm || '—' }}</p>
+          </div>
+          <div>
+            <p class="label">Item type</p>
+            <p class="value">{{ item.itemType | titlecase }}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </content>
+</ui-shell>
+
+<ng-template #missing>
+  <ui-shell>
+    <content class="detail-page">
+      <p class="muted">Item not found.</p>
+      <a routerLink="/inventory" class="primary">Back to inventory</a>
+    </content>
+  </ui-shell>
+</ng-template>

--- a/src/app/inventory/inventory-item-detail/inventory-item-detail.component.scss
+++ b/src/app/inventory/inventory-item-detail/inventory-item-detail.component.scss
@@ -1,0 +1,158 @@
+@use "../../../style/buttons.scss" as *;
+
+.detail-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #6b7280;
+
+  a {
+    color: #2563eb;
+    text-decoration: none;
+  }
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h1 {
+    margin: 0.2rem 0;
+  }
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+  margin: 0;
+}
+
+.muted {
+  color: #6b7280;
+  margin: 0;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
+  padding: 1rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.05);
+}
+
+.image-card img {
+  width: 100%;
+  border-radius: 10px;
+  object-fit: cover;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.price-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.cost-grid,
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.label {
+  font-size: 0.95rem;
+  color: #6b7280;
+  margin: 0 0 0.25rem;
+}
+
+.value {
+  font-weight: 700;
+  margin: 0;
+}
+
+.pill-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.pill {
+  background: #eef2ff;
+  color: #4338ca;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.warehouse-breakdown {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.warehouse-breakdown li {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #f8fafc;
+}
+
+button.primary {
+  @include primary-button;
+}
+
+button.secondary {
+  @include secondary-button;
+}
+
+button.ghost {
+  @include ghost-button;
+}
+
+button {
+  cursor: pointer;
+}

--- a/src/app/inventory/inventory-item-detail/inventory-item-detail.component.ts
+++ b/src/app/inventory/inventory-item-detail/inventory-item-detail.component.ts
@@ -1,0 +1,42 @@
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+import { InventoryItem } from '../../shared/models-and-mappers/item/item-model';
+import { InventoryService } from '../inventory.service';
+
+@Component({
+  selector: 'inventory-item-detail',
+  standalone: true,
+  imports: [CommonModule, CurrencyPipe, DatePipe, RouterLink, UiShellComponent],
+  templateUrl: './inventory-item-detail.component.html',
+  styleUrl: './inventory-item-detail.component.scss',
+})
+export class InventoryItemDetailComponent implements OnInit {
+  item?: InventoryItem;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly inventoryService: InventoryService,
+  ) {}
+
+  ngOnInit(): void {
+    const sku = this.route.snapshot.paramMap.get('sku');
+    if (sku) {
+      this.item = this.inventoryService.getBySku(sku);
+    }
+  }
+
+  goToAvailability(): void {
+    if (!this.item) return;
+    this.router.navigate(['/inventory', this.item.sku, 'availability']);
+  }
+
+  getNextTestDate(item: InventoryItem): string | undefined {
+    if (!item.lastTested || !item.nextTestDueMonths) return undefined;
+    const base = new Date(item.lastTested);
+    base.setMonth(base.getMonth() + item.nextTestDueMonths);
+    return base.toISOString();
+  }
+}

--- a/src/app/inventory/inventory.service.ts
+++ b/src/app/inventory/inventory.service.ts
@@ -1,0 +1,184 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { InventoryItem } from '../shared/models-and-mappers/item/item-model';
+
+const initialItems: InventoryItem[] = [
+  {
+    id: 1,
+    sku: '192176',
+    name: 'LED Fresnel 300W',
+    category: 'Lighting',
+    quantity: 18,
+    quantityAvailable: 12,
+    unitDayRate: 120,
+    itemType: 'rental',
+    itemMode: 'Serialised',
+    pricing: { oneDay: 120, threeDay: 290, week: 480 },
+    productCost: 900,
+    subhireCost: 75,
+    weightKg: 6.2,
+    dimensionsMm: '320 x 220 x 180',
+    roadcaseSize: '600',
+    roadcaseQuantity: 2,
+    lastTested: '2024-03-12',
+    nextTestDueMonths: 12,
+    imageUrl:
+      'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=600&q=80',
+    accessories: ['Barndoors', 'Powercon to 10A cable'],
+    accessoryTo: ['LED Fresnel Diffuser Kit'],
+    relatedSalesOrders: ['SO-1004', 'SO-1021'],
+    relatedRepairOrders: ['RO-212'],
+    relatedTransferOrders: ['TO-14'],
+    warehouseQuantities: [
+      { warehouse: 'Main Warehouse', quantity: 10 },
+      { warehouse: 'Tour Prep', quantity: 6 },
+      { warehouse: 'On Truck', quantity: 2 },
+    ],
+    availabilityBookings: [
+      {
+        orderId: 'SO-1004',
+        startDate: '2024-08-04',
+        endDate: '2024-08-07',
+        quantity: 4,
+        type: 'rental',
+      },
+      {
+        orderId: 'SO-1021',
+        startDate: '2024-08-15',
+        endDate: '2024-08-23',
+        quantity: 6,
+        type: 'rental',
+      },
+    ],
+  },
+  {
+    id: 2,
+    sku: '843512',
+    name: 'Shure SM58',
+    category: 'Audio',
+    quantity: 60,
+    quantityAvailable: 57,
+    unitDayRate: 12,
+    itemType: 'rental',
+    itemMode: 'Bulk',
+    pricing: { oneDay: 12, threeDay: 30, week: 54 },
+    productCost: 120,
+    subhireCost: 9,
+    weightKg: 0.3,
+    dimensionsMm: '151 x 51 x 51',
+    roadcaseSize: 'Cable or Small Item',
+    roadcaseQuantity: 15,
+    lastTested: '2024-05-02',
+    nextTestDueMonths: 6,
+    imageUrl:
+      'https://images.unsplash.com/photo-1485579149621-3123dd979885?auto=format&fit=crop&w=600&q=80',
+    accessories: ['Foam Windshield'],
+    accessoryTo: ['Wireless Beltpack Kit'],
+    relatedSalesOrders: ['SO-0999'],
+    relatedRepairOrders: [],
+    relatedTransferOrders: ['TO-19', 'TO-22'],
+    warehouseQuantities: [
+      { warehouse: 'Main Warehouse', quantity: 40 },
+      { warehouse: 'Festival Site', quantity: 15 },
+      { warehouse: 'Dry Hire Counter', quantity: 5 },
+    ],
+    availabilityBookings: [
+      {
+        orderId: 'SO-0999',
+        startDate: '2024-08-02',
+        endDate: '2024-08-05',
+        quantity: 12,
+        type: 'rental',
+      },
+    ],
+  },
+  {
+    id: 3,
+    sku: '564209',
+    name: '12m Truss Length',
+    category: 'Rigging',
+    quantity: 24,
+    quantityAvailable: 22,
+    unitDayRate: 55,
+    itemType: 'rental',
+    itemMode: 'Bulk',
+    pricing: { oneDay: 55, threeDay: 130, week: 220 },
+    productCost: 430,
+    subhireCost: 40,
+    weightKg: 18,
+    dimensionsMm: '12000 x 300 x 300',
+    roadcaseSize: '1800',
+    roadcaseQuantity: 4,
+    lastTested: '2024-01-18',
+    nextTestDueMonths: 24,
+    accessories: ['Truss Pin Pack'],
+    accessoryTo: [],
+    relatedSalesOrders: ['SO-0988'],
+    relatedRepairOrders: ['RO-214'],
+    relatedTransferOrders: [],
+    warehouseQuantities: [
+      { warehouse: 'Main Warehouse', quantity: 14 },
+      { warehouse: 'Arena Boneyard', quantity: 10 },
+    ],
+    availabilityBookings: [
+      {
+        orderId: 'SO-0988',
+        startDate: '2024-08-20',
+        endDate: '2024-08-28',
+        quantity: 8,
+        type: 'rental',
+      },
+    ],
+  },
+];
+
+@Injectable({ providedIn: 'root' })
+export class InventoryService {
+  private readonly itemsSubject = new BehaviorSubject<InventoryItem[]>(
+    initialItems,
+  );
+  readonly items$ = this.itemsSubject.asObservable();
+
+  list(): InventoryItem[] {
+    return this.itemsSubject.getValue();
+  }
+
+  getBySku(sku: string): InventoryItem | undefined {
+    return this.itemsSubject.getValue().find((item) => item.sku === sku);
+  }
+
+  addItem(newItem: Omit<InventoryItem, 'id' | 'sku'> & { sku?: string }) {
+    const items = this.itemsSubject.getValue();
+    const nextId = items.length
+      ? Math.max(...items.map((item) => item.id)) + 1
+      : 1;
+    const sku = newItem.sku ?? this.generateSku();
+    const itemToInsert: InventoryItem = {
+      ...newItem,
+      id: nextId,
+      sku,
+    };
+
+    this.itemsSubject.next([...items, itemToInsert]);
+    return itemToInsert;
+  }
+
+  updateItem(
+    sku: string,
+    payload: Partial<Omit<InventoryItem, 'sku' | 'id'>>,
+  ): InventoryItem | undefined {
+    const items = this.itemsSubject.getValue();
+    const index = items.findIndex((item) => item.sku === sku);
+    if (index === -1) return undefined;
+
+    const updated: InventoryItem = { ...items[index], ...payload };
+    const nextItems = [...items];
+    nextItems[index] = updated;
+    this.itemsSubject.next(nextItems);
+    return updated;
+  }
+
+  generateSku(): string {
+    return String(Math.floor(100000 + Math.random() * 900000));
+  }
+}

--- a/src/app/shared/models-and-mappers/item/item-model.ts
+++ b/src/app/shared/models-and-mappers/item/item-model.ts
@@ -1,7 +1,59 @@
-export interface Item {
+export type ItemType = 'sales' | 'rental' | 'consumable';
+export type ItemMode = 'Bulk' | 'Serialised';
+export type TestInterval = 3 | 6 | 12 | 24;
+
+export interface WarehouseQuantity {
+  warehouse: string;
+  quantity: number;
+}
+
+export interface ItemPricing {
+  oneDay: number;
+  threeDay: number;
+  week: number;
+}
+
+export interface ItemBooking {
+  orderId: string;
+  startDate: string;
+  endDate: string;
+  quantity: number;
+  type: ItemType;
+}
+
+export interface InventoryItem {
   id: number;
+  sku: string;
   name: string;
   category: string;
-  stock: number;
-  price: number;
+  quantity: number;
+  quantityAvailable: number;
+  unitDayRate: number;
+  itemType: ItemType;
+  itemMode: ItemMode;
+  pricing: ItemPricing;
+  productCost: number;
+  subhireCost: number;
+  weightKg?: number;
+  dimensionsMm?: string;
+  roadcaseSize?:
+    | '400'
+    | '600'
+    | '800'
+    | '1200'
+    | '1400'
+    | '1600'
+    | '1800'
+    | 'Cable or Small Item';
+  roadcaseQuantity?: number;
+  lastTested?: string;
+  nextTestDueMonths?: TestInterval;
+  imageUrl?: string;
+  accessories?: string[];
+  accessoryTo?: string[];
+  relatedSalesOrders?: string[];
+  relatedRepairOrders?: string[];
+  relatedTransferOrders?: string[];
+  warehouseQuantities: WarehouseQuantity[];
+  availabilityBookings?: ItemBooking[];
 }


### PR DESCRIPTION
## Summary
- add an inventory data service with seeded items and SKU generation
- redesign the inventory list with warehouse-aware creation modal and required columns
- add item detail and availability views with pricing, compliance, and booking timeline data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfc7c4e7083238a70a04d47117d9c)