### PR TITLE
Add sales orders listing and detail views

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -31,6 +31,15 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'sales/:orderNumber',
+    loadComponent: () =>
+      import(
+        './sales/sales-order-detail/sales-order-detail.component'
+      ).then((m) => m.SalesOrderDetailComponent),
+    title: 'Sales Order | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
     path: 'sales',
     loadComponent: () =>
       import('./sales/sales-component/sales-component').then(

--- a/src/app/sales/sales-component/sales-component.html
+++ b/src/app/sales/sales-component/sales-component.html
@@ -1,1 +1,79 @@
-<ui-shell></ui-shell>
+<ui-shell>
+  <content class="sales-content">
+    <div class="sales-header">
+      <div>
+        <p class="eyebrow">Commercial</p>
+        <h1>Sales Orders</h1>
+        <p class="subtitle">
+          Search, filter, and drill into sales orders across all branches.
+        </p>
+      </div>
+      <button class="secondary" type="button" (click)="clearFilters()">
+        Clear filters
+      </button>
+    </div>
+
+    <div class="filters">
+      <input
+        type="search"
+        placeholder="Search by sales order, title, or account manager"
+        [(ngModel)]="searchTerm"
+      />
+
+      <label class="inline-control">
+        <span>Branch</span>
+        <select [(ngModel)]="branchFilter">
+          <option *ngFor="let branch of branches" [value]="branch">
+            {{ branch }}
+          </option>
+        </select>
+      </label>
+
+      <label class="inline-control">
+        <span>Start from</span>
+        <input type="date" [(ngModel)]="dateFrom" />
+      </label>
+
+      <label class="inline-control">
+        <span>End by</span>
+        <input type="date" [(ngModel)]="dateTo" />
+      </label>
+    </div>
+
+    <div class="table-wrapper" *ngIf="filteredOrders.length; else emptyState">
+      <table>
+        <thead>
+          <tr>
+            <th>Sales Order #</th>
+            <th>Title</th>
+            <th>Account Manager</th>
+            <th>Start Date</th>
+            <th>End Date</th>
+            <th>Branch</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            *ngFor="let order of filteredOrders"
+            [routerLink]="['/sales', order.orderNumber]"
+          >
+            <td>{{ order.orderNumber }}</td>
+            <td>{{ order.title }}</td>
+            <td>{{ order.accountManager }}</td>
+            <td>{{ order.startDate | date: 'dd MMM yyyy' }}</td>
+            <td>{{ order.endDate | date: 'dd MMM yyyy' }}</td>
+            <td>{{ order.branch }}</td>
+            <td>{{ order.status }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <ng-template #emptyState>
+      <div class="empty-state">
+        <p>No sales orders match your filters.</p>
+      </div>
+    </ng-template>
+  </content>
+</ui-shell>

--- a/src/app/sales/sales-component/sales-component.scss
+++ b/src/app/sales/sales-component/sales-component.scss
@@ -1,0 +1,80 @@
+.sales-content {
+  padding: 1.5rem 2rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sales-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.subtitle {
+  color: #5b6472;
+  margin-top: 0.25rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #7b8699;
+  margin: 0;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.inline-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #394150;
+}
+
+.table-wrapper {
+  border: 1px solid #e3e7ee;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #fff;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f6f8fb;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #e3e7ee;
+}
+
+tr {
+  transition: background 0.15s ease;
+  cursor: pointer;
+}
+
+tr:hover {
+  background: #f0f4ff;
+}
+
+.empty-state {
+  padding: 1.5rem;
+  background: #f6f8fb;
+  border: 1px dashed #cfd6e2;
+  text-align: center;
+  border-radius: 10px;
+}

--- a/src/app/sales/sales-component/sales-component.ts
+++ b/src/app/sales/sales-component/sales-component.ts
@@ -1,10 +1,73 @@
-import { Component } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+import { SalesOrdersService, SalesOrderSummary } from '../sales-orders.service';
 
 @Component({
   selector: 'sales-component',
-  imports: [UiShellComponent],
+  standalone: true,
+  imports: [UiShellComponent, CommonModule, FormsModule, RouterLink, DatePipe],
   templateUrl: './sales-component.html',
   styleUrl: './sales-component.scss',
 })
-export class SalesComponent {}
+export class SalesComponent implements OnInit, OnDestroy {
+  orders: SalesOrderSummary[] = [];
+  searchTerm = '';
+  branchFilter = 'All';
+  dateFrom = '';
+  dateTo = '';
+
+  private readonly subscriptions: Subscription[] = [];
+
+  constructor(private readonly salesOrdersService: SalesOrdersService) {}
+
+  ngOnInit(): void {
+    this.subscriptions.push(
+      this.salesOrdersService.orders$.subscribe(
+        (orders) => (this.orders = orders),
+      ),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  get branches(): string[] {
+    const unique = Array.from(new Set(this.orders.map((order) => order.branch)));
+    return ['All', ...unique];
+  }
+
+  get filteredOrders(): SalesOrderSummary[] {
+    const term = this.searchTerm.toLowerCase();
+    return this.orders
+      .filter((order) =>
+        this.branchFilter === 'All' ? true : order.branch === this.branchFilter,
+      )
+      .filter((order) =>
+        term
+          ? [order.orderNumber, order.title, order.accountManager]
+              .join(' ')
+              .toLowerCase()
+              .includes(term)
+          : true,
+      )
+      .filter((order) => {
+        if (this.dateFrom && new Date(order.startDate) < new Date(this.dateFrom))
+          return false;
+        if (this.dateTo && new Date(order.endDate) > new Date(this.dateTo))
+          return false;
+        return true;
+      });
+  }
+
+  clearFilters() {
+    this.searchTerm = '';
+    this.branchFilter = 'All';
+    this.dateFrom = '';
+    this.dateTo = '';
+  }
+}

--- a/src/app/sales/sales-order-detail/sales-order-detail.component.html
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.html
@@ -1,0 +1,235 @@
+<ui-shell>
+  <content class="order-detail" *ngIf="order as current">
+    <div class="breadcrumb">
+      <a routerLink="/sales">Sales Orders</a>
+      <span>/</span>
+      <span class="crumb">{{ current.orderNumber }}</span>
+    </div>
+
+    <header class="order-header">
+      <div>
+        <p class="eyebrow">{{ current.orderType }}</p>
+        <h1>{{ current.title }}</h1>
+        <p class="meta">{{ current.orderNumber }} · {{ current.status }}</p>
+        <div class="tags">
+          <span *ngFor="let tag of current.tags">{{ tag }}</span>
+        </div>
+      </div>
+      <div class="totals">
+        <div>
+          <p class="label">Total excl. GST</p>
+          <p class="value">{{ totalExcl | currency: 'NZD':'symbol':'1.0-0' }}</p>
+        </div>
+        <div>
+          <p class="label">Total incl. GST</p>
+          <p class="value">{{ totalIncl | currency: 'NZD':'symbol':'1.0-0' }}</p>
+        </div>
+        <button type="button" class="primary" (click)="updateOrder()">
+          Save order
+        </button>
+      </div>
+    </header>
+
+    <section class="order-grid">
+      <div class="card">
+        <h3>Schedule</h3>
+        <dl>
+          <div>
+            <dt>Start date</dt>
+            <dd>{{ current.startDate | date: 'dd MMM yyyy' }}</dd>
+          </div>
+          <div>
+            <dt>End date</dt>
+            <dd>{{ current.endDate | date: 'dd MMM yyyy' }}</dd>
+          </div>
+          <div>
+            <dt>Billable days</dt>
+            <dd>
+              <input
+                type="number"
+                min="1"
+                [ngModel]="current.billableDays"
+                (ngModelChange)="updateBillableDays($event)"
+              />
+            </dd>
+          </div>
+          <div>
+            <dt>Rental period</dt>
+            <dd>{{ current.rentalPeriodDays }} days</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="card">
+        <h3>Customer</h3>
+        <dl>
+          <div>
+            <dt>Customer</dt>
+            <dd>{{ current.customer }}</dd>
+          </div>
+          <div>
+            <dt>Delivery location</dt>
+            <dd>{{ current.deliveryLocation }}</dd>
+          </div>
+          <div>
+            <dt>Service branch</dt>
+            <dd>{{ current.serviceBranch }}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd>{{ current.status }} / {{ current.warehouseStatus }}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="card">
+        <h3>Financial</h3>
+        <dl>
+          <div>
+            <dt>Global discount</dt>
+            <dd>
+              <select
+                [(ngModel)]="current.globalDiscount?.type"
+                (ngModelChange)="current.globalDiscount = current.globalDiscount || { type: 'percent', value: 0 }"
+              >
+                <option value="percent">% off subtotal</option>
+                <option value="amount">$ off subtotal</option>
+              </select>
+              <input
+                type="number"
+                min="0"
+                [(ngModel)]="current.globalDiscount!.value"
+              />
+            </dd>
+          </div>
+          <div>
+            <dt>Customer reference</dt>
+            <dd>{{ current.customerReference }}</dd>
+          </div>
+          <div>
+            <dt>Internal reference</dt>
+            <dd>{{ current.internalReference }}</dd>
+          </div>
+          <div>
+            <dt>Total discount</dt>
+            <dd>{{ totalDiscountValue | currency: 'NZD':'symbol':'1.0-0' }}</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <section class="stock">
+      <div class="stock-header">
+        <div>
+          <h2>Stock list</h2>
+          <p class="subtitle">
+            Group items, add subgroups, and use the picker to drop new items into
+            the correct section.
+          </p>
+        </div>
+        <button type="button" class="secondary" (click)="addGroup()">
+          + Add top-level group
+        </button>
+      </div>
+
+      <ng-template #groupTemplate let-group>
+        <div class="group">
+          <div class="group-header">
+            <input class="group-title" [(ngModel)]="group.title" />
+            <div class="group-actions">
+              <button type="button" (click)="addGroup(group.id)">+ Subgroup</button>
+              <button
+                type="button"
+                class="ghost"
+                (click)="togglePicker(group.id)"
+                aria-label="Open item picker"
+              >
+                🔍 Show picker
+              </button>
+            </div>
+          </div>
+
+          <div class="items" *ngIf="group.items.length">
+            <div class="item" *ngFor="let item of group.items">
+              <div>
+                <p class="item-name">{{ item.name }}</p>
+                <p class="item-meta">{{ item.sku }} · Qty {{ item.quantity }}</p>
+              </div>
+              <div class="pricing">
+                <label>
+                  <span>Discount</span>
+                  <select
+                    [ngModel]="item.discount?.type || ''"
+                    (ngModelChange)="setItemDiscountType(item, $event)"
+                  >
+                    <option value="">None</option>
+                    <option value="percent">%</option>
+                    <option value="amount">$</option>
+                  </select>
+                </label>
+                <input
+                  type="number"
+                  min="0"
+                  [ngModel]="item.discount?.value"
+                  (ngModelChange)="updateItemDiscountValue(item, $event)"
+                  [disabled]="!item.discount"
+                  placeholder="0"
+                />
+                <p class="item-total">
+                  {{ itemPrice(item, order?.billableDays || 1) | currency: 'NZD':'symbol':'1.0-0' }}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="picker" *ngIf="pickerState[group.id]?.isOpen">
+            <div class="picker-header">
+              <input
+                type="search"
+                placeholder="Search items"
+                [ngModel]="pickerState[group.id].search"
+                (ngModelChange)="onSearchChange(group.id, $event)"
+              />
+              <small>Showing up to 30 results</small>
+            </div>
+            <div class="picker-items">
+              <button
+                class="picker-item"
+                type="button"
+                *ngFor="let item of filteredLibrary(group.id)"
+                (click)="addItem(group.id, item)"
+              >
+                <div>
+                  <p class="item-name">{{ item.name }}</p>
+                  <p class="item-meta">{{ item.sku }}</p>
+                </div>
+                <span>{{ item.rates.oneDay | currency: 'NZD':'symbol':'1.0-0' }} / day</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="children" *ngIf="group.groups.length">
+            <ng-container
+              *ngFor="let child of group.groups"
+              [ngTemplateOutlet]="groupTemplate"
+              [ngTemplateOutletContext]="{ $implicit: child }"
+            ></ng-container>
+          </div>
+        </div>
+      </ng-template>
+
+      <div class="group-list" *ngIf="current.groups.length; else noGroups">
+        <ng-container
+          *ngFor="let group of current.groups"
+          [ngTemplateOutlet]="groupTemplate"
+          [ngTemplateOutletContext]="{ $implicit: group }"
+        ></ng-container>
+      </div>
+      <ng-template #noGroups>
+        <div class="empty-state">
+          <p>No groups yet. Create one to begin building the stock list.</p>
+        </div>
+      </ng-template>
+    </section>
+  </content>
+</ui-shell>

--- a/src/app/sales/sales-order-detail/sales-order-detail.component.scss
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.scss
@@ -1,0 +1,275 @@
+.order-detail {
+  padding: 1.5rem 2rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #6b7280;
+}
+
+.breadcrumb a {
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+.order-header {
+  background: #fff;
+  border: 1px solid #e3e7ee;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #7b8699;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+.meta {
+  color: #5b6472;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.tags span {
+  padding: 0.25rem 0.5rem;
+  background: #f3f4f6;
+  border-radius: 8px;
+  color: #394150;
+  font-size: 0.85rem;
+}
+
+.totals {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.totals .label {
+  color: #6b7280;
+  margin: 0;
+}
+
+.totals .value {
+  font-size: 1.35rem;
+  margin: 0.1rem 0 0.25rem;
+}
+
+.order-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e3e7ee;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card dl {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+
+.card dt {
+  font-weight: 600;
+  color: #111827;
+}
+
+.card dd {
+  margin: 0.15rem 0 0;
+  color: #4b5563;
+}
+
+.stock {
+  background: #fff;
+  border: 1px solid #e3e7ee;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stock-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.subtitle {
+  color: #5b6472;
+  margin: 0.15rem 0 0;
+}
+
+.group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.group {
+  border: 1px solid #e3e7ee;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  background: #f9fafb;
+}
+
+.group-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.group-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  border: none;
+  background: transparent;
+  padding: 0.25rem 0.5rem;
+}
+
+.group-title:focus {
+  outline: 2px solid #a5b4fc;
+  border-radius: 8px;
+}
+
+.group-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.group-actions .ghost {
+  background: transparent;
+  border: 1px dashed #c7cdd9;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  background: #fff;
+  border: 1px solid #e3e7ee;
+}
+
+.item-name {
+  font-weight: 600;
+  margin: 0;
+}
+
+.item-meta {
+  margin: 0.2rem 0 0;
+  color: #6b7280;
+}
+
+.pricing {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pricing label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.pricing input {
+  width: 90px;
+}
+
+.item-total {
+  font-weight: 700;
+  margin: 0;
+}
+
+.picker {
+  margin-top: 0.75rem;
+  border: 1px dashed #c7cdd9;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #fff;
+}
+
+.picker-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.picker-items {
+  max-height: 280px;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.5rem;
+}
+
+.picker-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  transition: border 0.15s ease, background 0.15s ease;
+}
+
+.picker-item:hover {
+  border-color: #a5b4fc;
+  background: #eef2ff;
+}
+
+.children {
+  margin-top: 0.75rem;
+  border-left: 2px solid #e3e7ee;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.empty-state {
+  padding: 1rem;
+  background: #f6f8fb;
+  border: 1px dashed #cfd6e2;
+  border-radius: 10px;
+  text-align: center;
+}

--- a/src/app/sales/sales-order-detail/sales-order-detail.component.ts
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.ts
@@ -1,0 +1,274 @@
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Subscription } from 'rxjs';
+import {
+  Discount,
+  SalesOrderSummary,
+  SalesOrdersService,
+  StockGroup,
+  StockItem,
+} from '../sales-orders.service';
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+
+interface PickerState {
+  search: string;
+  isOpen: boolean;
+}
+
+@Component({
+  selector: 'sales-order-detail',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    RouterLink,
+    CurrencyPipe,
+    DatePipe,
+    UiShellComponent,
+  ],
+  templateUrl: './sales-order-detail.component.html',
+  styleUrl: './sales-order-detail.component.scss',
+})
+export class SalesOrderDetailComponent implements OnInit, OnDestroy {
+  order?: SalesOrderSummary;
+  pickerState: Record<string, PickerState> = {};
+  availableItems: StockItem[] = [
+    {
+      id: 'lib-1',
+      name: 'Wireless Microphone Kit',
+      sku: 'AUD-220',
+      quantity: 1,
+      rates: { oneDay: 45, threeDay: 120, week: 180 },
+    },
+    {
+      id: 'lib-2',
+      name: 'Moving Head Spot',
+      sku: 'LGT-501',
+      quantity: 1,
+      rates: { oneDay: 75, threeDay: 195, week: 280 },
+    },
+    {
+      id: 'lib-3',
+      name: 'Stage Deck 1m x 2m',
+      sku: 'STG-102',
+      quantity: 1,
+      rates: { oneDay: 30, threeDay: 80, week: 120 },
+    },
+    {
+      id: 'lib-4',
+      name: 'Power Cable 10m',
+      sku: 'CAB-010',
+      quantity: 1,
+      rates: { oneDay: 5, threeDay: 12, week: 18 },
+    },
+    {
+      id: 'lib-5',
+      name: 'Video Switcher',
+      sku: 'VID-303',
+      quantity: 1,
+      rates: { oneDay: 180, threeDay: 470, week: 680 },
+    },
+    {
+      id: 'lib-6',
+      name: 'Lighting Console',
+      sku: 'LGT-900',
+      quantity: 1,
+      rates: { oneDay: 140, threeDay: 360, week: 520 },
+    },
+  ];
+
+  private readonly subscriptions: Subscription[] = [];
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly salesOrdersService: SalesOrdersService,
+  ) {}
+
+  ngOnInit(): void {
+    this.subscriptions.push(
+      this.route.paramMap.subscribe((params) => {
+        const orderNumber = params.get('orderNumber');
+        if (!orderNumber) {
+          return;
+        }
+        const order = this.salesOrdersService.getOrderByNumber(orderNumber);
+        if (!order) {
+          this.router.navigate(['/sales']);
+          return;
+        }
+        this.order = JSON.parse(JSON.stringify(order));
+        if (!this.order.globalDiscount) {
+          this.order.globalDiscount = { type: 'percent', value: 0 };
+        }
+        this.seedPickerState(this.order.groups);
+      }),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  private seedPickerState(groups: StockGroup[]) {
+    groups.forEach((group) => {
+      this.pickerState[group.id] = { search: '', isOpen: false };
+      if (group.groups.length) {
+        this.seedPickerState(group.groups);
+      }
+    });
+  }
+
+  togglePicker(groupId: string) {
+    const state = this.pickerState[groupId];
+    this.pickerState[groupId] = {
+      ...(state || { search: '' }),
+      isOpen: !state?.isOpen,
+    };
+  }
+
+  filteredLibrary(groupId: string): StockItem[] {
+    const state = this.pickerState[groupId];
+    const term = state?.search?.toLowerCase() ?? '';
+    return this.availableItems
+      .filter((item) =>
+        term
+          ? [item.name, item.sku].join(' ').toLowerCase().includes(term)
+          : true,
+      )
+      .slice(0, 30);
+  }
+
+  onSearchChange(groupId: string, value: string) {
+    this.pickerState[groupId] = {
+      ...(this.pickerState[groupId] || { isOpen: true }),
+      search: value,
+    };
+  }
+
+  addItem(groupId: string, libraryItem: StockItem) {
+    if (!this.order) return;
+    const clone: StockItem = {
+      ...libraryItem,
+      id: `${libraryItem.id}-${crypto.randomUUID()}`,
+    };
+    this.applyToGroup(this.order.groups, groupId, (group) => {
+      group.items = [...group.items, clone];
+    });
+  }
+
+  addGroup(parentId?: string) {
+    if (!this.order) return;
+    const newGroup: StockGroup = {
+      id: `grp-${crypto.randomUUID()}`,
+      title: 'New Group',
+      items: [],
+      groups: [],
+    };
+
+    if (!parentId) {
+      this.order.groups = [...this.order.groups, newGroup];
+      this.pickerState[newGroup.id] = { search: '', isOpen: false };
+      return;
+    }
+
+    this.applyToGroup(this.order.groups, parentId, (group) => {
+      group.groups = [...group.groups, newGroup];
+      this.pickerState[newGroup.id] = { search: '', isOpen: false };
+    });
+  }
+
+  private applyToGroup(
+    groups: StockGroup[],
+    targetId: string,
+    mutate: (group: StockGroup) => void,
+  ) {
+    for (const group of groups) {
+      if (group.id === targetId) {
+        mutate(group);
+        return;
+      }
+      if (group.groups?.length) {
+        this.applyToGroup(group.groups, targetId, mutate);
+      }
+    }
+  }
+
+  updateBillableDays(value: number) {
+    if (!this.order) return;
+    this.order.billableDays = Number(value) || 1;
+  }
+
+  setItemDiscountType(
+    item: StockItem,
+    discountType: Discount['type'] | '',
+  ) {
+    if (!discountType) {
+      item.discount = undefined;
+      return;
+    }
+    item.discount = item.discount ?? { type: discountType, value: 0 };
+    item.discount.type = discountType;
+  }
+
+  updateItemDiscountValue(item: StockItem, value: number) {
+    if (!item.discount) {
+      item.discount = { type: 'percent', value };
+      return;
+    }
+    item.discount.value = value;
+  }
+
+  updateOrder() {
+    if (!this.order) return;
+    this.salesOrdersService.updateOrder(this.order);
+  }
+
+  itemPrice(item: StockItem, billableDays: number): number {
+    const oneDayPrice = item.rates.oneDay * billableDays;
+    const threeDayPrice = item.rates.threeDay ?? oneDayPrice;
+    const weekPrice = item.rates.week ?? Math.min(oneDayPrice, threeDayPrice);
+    const base = Math.min(oneDayPrice, threeDayPrice, weekPrice);
+
+    if (!item.discount) return base * item.quantity;
+    return (
+      base * item.quantity -
+      this.calculateDiscount(base * item.quantity, item.discount)
+    );
+  }
+
+  private calculateDiscount(amount: number, discount: Discount): number {
+    if (discount.type === 'percent') {
+      return (amount * discount.value) / 100;
+    }
+    return discount.value;
+  }
+
+  get subtotal(): number {
+    if (!this.order) return 0;
+    return this.order.groups
+      .flatMap((group) => this.collectItems(group))
+      .reduce((sum, item) => sum + this.itemPrice(item, this.order!.billableDays), 0);
+  }
+
+  private collectItems(group: StockGroup): StockItem[] {
+    const items = [...group.items];
+    group.groups.forEach((child) => items.push(...this.collectItems(child)));
+    return items;
+  }
+
+  get totalDiscountValue(): number {
+    if (!this.order?.globalDiscount) return 0;
+    return this.calculateDiscount(this.subtotal, this.order.globalDiscount);
+  }
+
+  get totalExcl(): number {
+    return Math.max(this.subtotal - this.totalDiscountValue, 0);
+  }
+
+  get totalIncl(): number {
+    return this.totalExcl * 1.15;
+  }
+}

--- a/src/app/sales/sales-orders.service.ts
+++ b/src/app/sales/sales-orders.service.ts
@@ -1,0 +1,191 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type OrderStatus =
+  | 'Quote'
+  | 'Confirmed'
+  | 'Invoiced'
+  | 'Completed'
+  | 'Dead';
+
+export type WarehouseStatus =
+  | 'To Prep'
+  | 'Prepped'
+  | 'Loaded'
+  | 'With Client'
+  | 'Returned'
+  | 'Partial Return'
+  | 'Completed';
+
+export type OrderType = 'Production' | 'Dry Hire' | 'Stock Transfer';
+
+export interface Discount {
+  type: 'percent' | 'amount';
+  value: number;
+}
+
+export interface StockItem {
+  id: string;
+  name: string;
+  sku: string;
+  quantity: number;
+  rates: {
+    oneDay: number;
+    threeDay?: number;
+    week?: number;
+  };
+  discount?: Discount;
+}
+
+export interface StockGroup {
+  id: string;
+  title: string;
+  items: StockItem[];
+  groups: StockGroup[];
+}
+
+export interface SalesOrderSummary {
+  id: string;
+  orderNumber: string;
+  title: string;
+  accountManager: string;
+  startDate: string;
+  endDate: string;
+  branch: string;
+  customer: string;
+  deliveryLocation: string;
+  serviceBranch: string;
+  status: OrderStatus;
+  warehouseStatus: WarehouseStatus;
+  internalReference: string;
+  customerReference: string;
+  totalDiscount: number;
+  billableDays: number;
+  rentalPeriodDays: number;
+  tags: string[];
+  orderType: OrderType;
+  globalDiscount?: Discount;
+  groups: StockGroup[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class SalesOrdersService {
+  private readonly ordersSubject = new BehaviorSubject<SalesOrderSummary[]>([
+    {
+      id: 'so-1001',
+      orderNumber: 'SO-1001',
+      title: 'Corporate Gala AV',
+      accountManager: 'Jessie McCarthy',
+      startDate: '2024-08-12',
+      endDate: '2024-08-15',
+      branch: 'Christchurch',
+      customer: 'Canterbury Insurance Group',
+      deliveryLocation: 'Te Pae Convention Centre',
+      serviceBranch: 'Christchurch',
+      status: 'Confirmed',
+      warehouseStatus: 'Prepped',
+      internalReference: 'SO-1001',
+      customerReference: 'PO-88394',
+      totalDiscount: 150,
+      billableDays: 3,
+      rentalPeriodDays: 4,
+      orderType: 'Production',
+      tags: ['AV', 'Gala'],
+      globalDiscount: { type: 'amount', value: 300 },
+      groups: [
+        {
+          id: 'grp-stage',
+          title: 'Stage Package',
+          items: [
+            {
+              id: 'itm-1',
+              name: 'LED Wash Light',
+              sku: 'LGT-203',
+              quantity: 12,
+              rates: { oneDay: 65, threeDay: 170, week: 240 },
+              discount: { type: 'percent', value: 5 },
+            },
+            {
+              id: 'itm-2',
+              name: 'Power Distro 32A',
+              sku: 'PWR-009',
+              quantity: 2,
+              rates: { oneDay: 120, threeDay: 300, week: 420 },
+            },
+          ],
+          groups: [
+            {
+              id: 'grp-rigging',
+              title: 'Rigging',
+              items: [
+                {
+                  id: 'itm-3',
+                  name: 'Truss 3m',
+                  sku: 'TRS-300',
+                  quantity: 6,
+                  rates: { oneDay: 40, threeDay: 100, week: 145 },
+                  discount: { type: 'amount', value: 30 },
+                },
+              ],
+              groups: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'so-1002',
+      orderNumber: 'SO-1002',
+      title: 'Outdoor Concert PA',
+      accountManager: 'Teuila Morgan',
+      startDate: '2024-09-02',
+      endDate: '2024-09-07',
+      branch: 'Dunedin',
+      customer: 'Southern Summer Events',
+      deliveryLocation: 'Forsyth Barr Stadium',
+      serviceBranch: 'Dunedin',
+      status: 'Quote',
+      warehouseStatus: 'To Prep',
+      internalReference: 'SO-1002',
+      customerReference: 'PO-99231',
+      totalDiscount: 0,
+      billableDays: 5,
+      rentalPeriodDays: 6,
+      orderType: 'Dry Hire',
+      tags: ['Audio'],
+      groups: [
+        {
+          id: 'grp-pa',
+          title: 'PA System',
+          items: [
+            {
+              id: 'itm-4',
+              name: 'Line Array Element',
+              sku: 'AUD-401',
+              quantity: 16,
+              rates: { oneDay: 85, threeDay: 210, week: 320 },
+            },
+          ],
+          groups: [],
+        },
+      ],
+    },
+  ]);
+
+  readonly orders$ = this.ordersSubject.asObservable();
+
+  get orders(): SalesOrderSummary[] {
+    return this.ordersSubject.getValue();
+  }
+
+  getOrderByNumber(orderNumber: string): SalesOrderSummary | undefined {
+    return this.orders.find((order) => order.orderNumber === orderNumber);
+  }
+
+  updateOrder(updated: SalesOrderSummary) {
+    const orders = this.orders.map((order) =>
+      order.id === updated.id ? updated : order,
+    );
+    this.ordersSubject.next(orders);
+  }
+}


### PR DESCRIPTION
## Summary
- add searchable, filterable sales orders list with branch and date filtering
- create sales order detail view with editable groups, item picker, and order meta display
- introduce sales order data service with mock data feeding list and detail screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c0a73be1c83239256a253454751f1)