### PR TITLE
Add drag-and-drop management for sales order items

### DIFF
--- a/src/app/sales/sales-order-detail/sales-order-detail.component.html
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.html
@@ -178,6 +178,9 @@
               <button type="button" (click)="addGroup(group.id)">
                 + Subgroup
               </button>
+              <button type="button" class="quiet-button" (click)="removeGroup(group.id)">
+                Delete
+              </button>
               <button
                 type="button"
                 class="quiet-button"
@@ -189,45 +192,63 @@
             </div>
           </div>
 
-          <div class="items" *ngIf="group.items.length">
-            <div class="item" *ngFor="let item of group.items">
+          <div
+            class="items"
+            (dragover)="onDragOver($event)"
+            (drop)="onDrop($event, group.id)"
+          >
+            <div class="item-grid-header">
+              <span class="center">Move</span>
+              <span>Item</span>
+              <span class="center">Qty</span>
+              <span class="center">Days</span>
+              <span class="center">Discount</span>
+              <span class="right">Price</span>
+              <span class="sr-only">Actions</span>
+            </div>
+            <div
+              class="item"
+              *ngFor="let item of group.items; let i = index"
+              draggable="true"
+              [class.dragging]="isDraggingItem(item.id)"
+              (dragstart)="startDrag(group.id, item.id)"
+              (dragend)="endDrag()"
+              (dragover)="onDragOver($event)"
+              (drop)="onDrop($event, group.id, i)"
+            >
+              <div class="drag-handle" title="Drag to reorder">
+                ☰
+              </div>
               <div>
                 <p class="item-name">{{ item.name }}</p>
                 <p class="item-meta">{{ item.sku }}</p>
               </div>
-              <div class="item-controls">
-                <label>
-                  <span>Qty</span>
-                  <input
-                    type="number"
-                    min="1"
-                    [ngModel]="item.quantity"
-                    (ngModelChange)="updateItemQuantity(item, $event)"
-                  />
-                </label>
-                <label>
-                  <span>Days</span>
-                  <input
-                    type="number"
-                    min="1"
-                    [ngModel]="item.billableDays"
-                    (ngModelChange)="updateItemBillableDays(item, $event)"
-                    [placeholder]="order?.billableDays?.toString()"
-                  />
-                </label>
+              <div class="item-cell">
+                <input
+                  type="number"
+                  min="1"
+                  [ngModel]="item.quantity"
+                  (ngModelChange)="updateItemQuantity(item, $event)"
+                />
               </div>
-              <div class="pricing">
-                <label>
-                  <span>Discount</span>
-                  <select
-                    [ngModel]="item.discount?.type || ''"
-                    (ngModelChange)="setItemDiscountType(item, $event)"
-                  >
-                    <option value="">None</option>
-                    <option value="percent">%</option>
-                    <option value="amount">$</option>
-                  </select>
-                </label>
+              <div class="item-cell">
+                <input
+                  type="number"
+                  min="1"
+                  [ngModel]="item.billableDays"
+                  (ngModelChange)="updateItemBillableDays(item, $event)"
+                  [placeholder]="order?.billableDays?.toString()"
+                />
+              </div>
+              <div class="item-cell discount">
+                <select
+                  [ngModel]="item.discount?.type || ''"
+                  (ngModelChange)="setItemDiscountType(item, $event)"
+                >
+                  <option value="">None</option>
+                  <option value="percent">%</option>
+                  <option value="amount">$</option>
+                </select>
                 <input
                   type="number"
                   min="0"
@@ -236,10 +257,21 @@
                   [disabled]="!item.discount"
                   placeholder="0"
                 />
-                <p class="item-total">
-                  {{ itemPrice(item) | currency: "NZD" : "symbol" : "1.0-0" }}
-                </p>
               </div>
+              <p class="item-total">
+                {{ itemPrice(item) | currency: "NZD" : "symbol" : "1.0-0" }}
+              </p>
+              <button
+                type="button"
+                class="icon-button"
+                aria-label="Remove item"
+                (click)="removeItem(group.id, item.id)"
+              >
+                ✕
+              </button>
+            </div>
+            <div *ngIf="!group.items.length" class="empty-items">
+              Drop items here or use the picker.
             </div>
           </div>
 

--- a/src/app/sales/sales-order-detail/sales-order-detail.component.scss
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.scss
@@ -169,6 +169,12 @@
   gap: 0.5rem;
 }
 
+.group-actions .quiet-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .quiet-button {
   background: transparent;
   border: 1px solid #c7cdd9;
@@ -187,18 +193,57 @@
 .items {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
   margin-top: 0.35rem;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.35rem;
+}
+
+.item-grid-header {
+  display: grid;
+  grid-template-columns: 40px minmax(200px, 1fr) 80px 80px 180px 110px 40px;
+  gap: 0.5rem;
+  padding: 0 0.35rem;
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 .item {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 40px minmax(200px, 1fr) 80px 80px 180px 110px 40px;
+  gap: 0.5rem;
   align-items: center;
-  padding: 0.35rem 0.5rem;
+  padding: 0.4rem 0.35rem;
   border-radius: 6px;
   background: #fff;
   border: 1px solid #e3e7ee;
+}
+
+.item.dragging {
+  opacity: 0.6;
+}
+
+.drag-handle {
+  grid-row: 1 / span 2;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  cursor: grab;
+  user-select: none;
+}
+
+.item-grid-header .center,
+.item .item-cell input,
+.item .item-total,
+.item .icon-button,
+.item .discount select,
+.item .discount input {
+  text-align: center;
 }
 
 .item-name {
@@ -212,47 +257,57 @@
   font-size: 0.9rem;
 }
 
-.item-controls {
+.item-cell {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  justify-content: center;
 }
 
-.item-controls label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  color: #4b5563;
-  font-size: 0.85rem;
+.item-cell input,
+.item-cell select {
+  width: 100%;
+  max-width: 90px;
+  padding: 0.3rem 0.4rem;
 }
 
-.item-controls input {
-  width: 70px;
-  padding: 0.2rem 0.35rem;
-}
-
-.pricing {
-  display: flex;
+.discount {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.3rem;
   align-items: center;
-  gap: 0.35rem;
-}
-
-.pricing label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  color: #4b5563;
-  font-size: 0.9rem;
-}
-
-.pricing input {
-  width: 80px;
-  padding: 0.25rem 0.4rem;
 }
 
 .item-total {
   font-weight: 700;
   margin: 0;
+  text-align: right;
+}
+
+.icon-button {
+  border: none;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.icon-button:hover {
+  color: #ef4444;
+}
+
+.empty-items {
+  padding: 0.5rem 0.35rem;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 


### PR DESCRIPTION
## Summary
- add delete controls for stock groups and individual items in the sales order detail view
- implement native drag and drop to reorder items within and across groups
- streamline the stock list layout with shared headers and compact row styling

## Testing
- npm start -- --host 0.0.0.0 --port 4200


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e89b100fc83239db93c2b0cdc49c0)