### PR TITLE
Refine sales order discounts and layout

### DIFF
--- a/src/app/sales/sales-order-detail/sales-order-detail.component.html
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.html
@@ -28,9 +28,6 @@
             {{ totalIncl | currency: "NZD" : "symbol" : "1.0-0" }}
           </p>
         </div>
-        <button type="button" class="primary" (click)="updateOrder()">
-          Save order
-        </button>
       </div>
     </header>
 
@@ -107,34 +104,16 @@
       <div class="card">
         <div class="card-heading">
           <h3>Financial</h3>
-          <button
-            type="button"
-            class="edit-button"
-            (click)="openEdit('financial')"
-          >
-            Edit
-          </button>
         </div>
         <dl>
           <div>
             <dt>Global discount</dt>
             <dd>
-              <select
-                [ngModel]="current.globalDiscount?.type"
-                (ngModelChange)="
-                  current.globalDiscount = current.globalDiscount || {
-                    type: 'percent',
-                    value: 0,
-                  }
-                "
-              >
-                <option value="percent">% off subtotal</option>
-                <option value="amount">$ off subtotal</option>
-              </select>
               <input
-                type="number"
-                min="0"
-                [(ngModel)]="current.globalDiscount!.value"
+                type="text"
+                placeholder="10% or $10"
+                [ngModel]="formatDiscount(current.globalDiscount)"
+                (ngModelChange)="updateGlobalDiscountInput($event)"
               />
             </dd>
           </div>
@@ -178,6 +157,9 @@
               <button type="button" (click)="addGroup(group.id)">
                 + Subgroup
               </button>
+              <button type="button" class="quiet-button" (click)="removeGroup(group.id)">
+                Delete
+              </button>
               <button
                 type="button"
                 class="quiet-button"
@@ -189,57 +171,78 @@
             </div>
           </div>
 
-          <div class="items" *ngIf="group.items.length">
-            <div class="item" *ngFor="let item of group.items">
-              <div>
-                <p class="item-name">{{ item.name }}</p>
-                <p class="item-meta">{{ item.sku }}</p>
+          <div
+            class="items"
+            (dragover)="onDragOver($event)"
+            (drop)="onDrop($event, group.id)"
+          >
+            <div class="item-grid-header">
+              <span class="center">Move</span>
+              <span>Item</span>
+              <span class="center">Qty</span>
+              <span class="center">Days</span>
+              <span class="center">Discount</span>
+              <span class="right">Price</span>
+              <span class="sr-only">Actions</span>
+            </div>
+            <div
+              class="item"
+              *ngFor="let item of group.items; let i = index"
+              draggable="true"
+              [class.dragging]="isDraggingItem(item.id)"
+              (dragstart)="startDrag(group.id, item.id)"
+              (dragend)="endDrag()"
+              (dragover)="onDragOver($event)"
+              (drop)="onDrop($event, group.id, i)"
+            >
+              <div class="drag-handle" title="Drag to reorder">
+                ☰
               </div>
-              <div class="item-controls">
-                <label>
-                  <span>Qty</span>
-                  <input
-                    type="number"
-                    min="1"
-                    [ngModel]="item.quantity"
-                    (ngModelChange)="updateItemQuantity(item, $event)"
-                  />
-                </label>
-                <label>
-                  <span>Days</span>
-                  <input
-                    type="number"
-                    min="1"
-                    [ngModel]="item.billableDays"
-                    (ngModelChange)="updateItemBillableDays(item, $event)"
-                    [placeholder]="order?.billableDays?.toString()"
-                  />
-                </label>
-              </div>
-              <div class="pricing">
-                <label>
-                  <span>Discount</span>
-                  <select
-                    [ngModel]="item.discount?.type || ''"
-                    (ngModelChange)="setItemDiscountType(item, $event)"
-                  >
-                    <option value="">None</option>
-                    <option value="percent">%</option>
-                    <option value="amount">$</option>
-                  </select>
-                </label>
-                <input
-                  type="number"
-                  min="0"
-                  [ngModel]="item.discount?.value"
-                  (ngModelChange)="updateItemDiscountValue(item, $event)"
-                  [disabled]="!item.discount"
-                  placeholder="0"
-                />
-                <p class="item-total">
-                  {{ itemPrice(item) | currency: "NZD" : "symbol" : "1.0-0" }}
+              <div class="item-title">
+                <p class="item-name">
+                  {{ item.name }}
+                  <span class="item-sku">· {{ item.sku }}</span>
                 </p>
               </div>
+              <div class="item-cell">
+                <input
+                  type="number"
+                  min="1"
+                  [ngModel]="item.quantity"
+                  (ngModelChange)="updateItemQuantity(item, $event)"
+                />
+              </div>
+              <div class="item-cell">
+                <input
+                  type="number"
+                  min="1"
+                  [ngModel]="item.billableDays"
+                  (ngModelChange)="updateItemBillableDays(item, $event)"
+                  [placeholder]="order?.billableDays?.toString()"
+                />
+              </div>
+              <div class="item-cell discount">
+                <input
+                  type="text"
+                  placeholder="10% or $10"
+                  [ngModel]="formatDiscount(item.discount)"
+                  (ngModelChange)="updateItemDiscountInput(item, $event)"
+                />
+              </div>
+              <p class="item-total">
+                {{ itemPrice(item) | currency: "NZD" : "symbol" : "1.0-0" }}
+              </p>
+              <button
+                type="button"
+                class="icon-button"
+                aria-label="Remove item"
+                (click)="removeItem(group.id, item.id)"
+              >
+                ✕
+              </button>
+            </div>
+            <div *ngIf="!group.items.length" class="empty-items">
+              Drop items here or use the picker.
             </div>
           </div>
 
@@ -444,18 +447,12 @@
 
           <ng-container *ngSwitchCase="'financial'">
             <label>
-              <span>Global discount type</span>
-              <select [(ngModel)]="draftFinancial.globalDiscountType">
-                <option value="percent">Percent</option>
-                <option value="amount">Amount</option>
-              </select>
-            </label>
-            <label>
               <span>Global discount value</span>
               <input
-                type="number"
-                min="0"
-                [(ngModel)]="draftFinancial.globalDiscountValue"
+                type="text"
+                placeholder="10% or $10"
+                [ngModel]="formatDiscountDraft()"
+                (ngModelChange)="updateDraftFinancialDiscount($event)"
               />
             </label>
             <label>

--- a/src/app/sales/sales-order-detail/sales-order-detail.component.scss
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.scss
@@ -169,6 +169,12 @@
   gap: 0.5rem;
 }
 
+.group-actions .quiet-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .quiet-button {
   background: transparent;
   border: 1px solid #c7cdd9;
@@ -187,23 +193,76 @@
 .items {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
   margin-top: 0.35rem;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.35rem;
+}
+
+.item-grid-header {
+  display: grid;
+  grid-template-columns: 40px minmax(200px, 1fr) 80px 80px 180px 110px 40px;
+  gap: 0.5rem;
+  padding: 0 0.35rem;
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 .item {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 40px minmax(200px, 1fr) 80px 80px 180px 110px 40px;
+  gap: 0.5rem;
   align-items: center;
-  padding: 0.35rem 0.5rem;
+  padding: 0.4rem 0.35rem;
   border-radius: 6px;
   background: #fff;
   border: 1px solid #e3e7ee;
 }
 
+.item.dragging {
+  opacity: 0.6;
+}
+
+.drag-handle {
+  grid-row: 1 / span 2;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #9ca3af;
+  cursor: grab;
+  user-select: none;
+}
+
+.item-grid-header .center,
+.item .item-cell input,
+.item .item-total,
+.item .icon-button,
+.item .discount select,
+.item .discount input {
+  text-align: center;
+}
+
+.item-title {
+  display: flex;
+  align-items: center;
+}
+
 .item-name {
   font-weight: 600;
   margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.item-sku {
+  color: #6b7280;
+  font-size: 0.9rem;
+  font-weight: 500;
 }
 
 .item-meta {
@@ -212,47 +271,55 @@
   font-size: 0.9rem;
 }
 
-.item-controls {
+.item-cell {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  justify-content: center;
 }
 
-.item-controls label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  color: #4b5563;
-  font-size: 0.85rem;
+.item-cell input,
+.item-cell select {
+  width: 100%;
+  max-width: 90px;
+  padding: 0.3rem 0.4rem;
 }
 
-.item-controls input {
-  width: 70px;
-  padding: 0.2rem 0.35rem;
-}
-
-.pricing {
+.discount {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
-}
-
-.pricing label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  color: #4b5563;
-  font-size: 0.9rem;
-}
-
-.pricing input {
-  width: 80px;
-  padding: 0.25rem 0.4rem;
 }
 
 .item-total {
   font-weight: 700;
   margin: 0;
+  text-align: right;
+}
+
+.icon-button {
+  border: none;
+  background: transparent;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.icon-button:hover {
+  color: #ef4444;
+}
+
+.empty-items {
+  padding: 0.5rem 0.35rem;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 
@@ -364,6 +431,18 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.children .group {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0 0 0;
+}
+
+.children .items {
+  background: transparent;
+  border: none;
+  padding: 0.35rem 0 0.35rem 0;
 }
 
 .empty-state {

--- a/src/app/sales/sales-order-detail/sales-order-detail.component.ts
+++ b/src/app/sales/sales-order-detail/sales-order-detail.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -58,12 +58,16 @@ export class SalesOrderDetailComponent implements OnInit, OnDestroy {
     orderType: 'Dry Hire' as SalesOrderSummary['orderType'],
     tags: '' as string,
   };
-  draftFinancial = {
-    globalDiscountType: 'percent' as Discount['type'],
-    globalDiscountValue: 0,
+  draftFinancial: {
+    discount?: Discount;
+    customerReference: string;
+    totalDiscount: number;
+  } = {
+    discount: { type: 'percent', value: 0 },
     customerReference: '',
     totalDiscount: 0,
   };
+  draggedItem: { groupId: string; itemId: string } | null = null;
 
   private readonly subscriptions: Subscription[] = [];
 
@@ -95,7 +99,17 @@ export class SalesOrderDetailComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (this.order) {
+      this.updateOrder();
+    }
     this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  @HostListener('window:beforeunload')
+  handleBeforeUnload() {
+    if (this.order) {
+      this.updateOrder();
+    }
   }
 
   openPicker(groupId: string) {
@@ -192,6 +206,94 @@ export class SalesOrderDetailComponent implements OnInit, OnDestroy {
     });
   }
 
+  removeItem(groupId: string, itemId: string) {
+    if (!this.order) return;
+    this.applyToGroup(this.order.groups, groupId, (group) => {
+      group.items = group.items.filter((item) => item.id !== itemId);
+    });
+  }
+
+  removeGroup(groupId: string) {
+    if (!this.order) return;
+    this.order.groups = this.pruneGroup(this.order.groups, groupId);
+  }
+
+  startDrag(groupId: string, itemId: string) {
+    this.draggedItem = { groupId, itemId };
+  }
+
+  endDrag() {
+    this.draggedItem = null;
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent, targetGroupId: string, targetIndex?: number) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (!this.order || !this.draggedItem) return;
+
+    const { groupId: sourceGroupId, itemId } = this.draggedItem;
+    let removedIndex: number | null = null;
+    let movingItem: StockItem | undefined;
+
+    this.applyToGroup(this.order.groups, sourceGroupId, (group) => {
+      const idx = group.items.findIndex((item) => item.id === itemId);
+      if (idx !== -1) {
+        removedIndex = idx;
+        [movingItem] = group.items.splice(idx, 1);
+      }
+    });
+
+    if (!movingItem) {
+      this.draggedItem = null;
+      return;
+    }
+
+    let inserted = false;
+
+    this.applyToGroup(this.order.groups, targetGroupId, (group) => {
+      let insertAt =
+        typeof targetIndex === 'number' ? targetIndex : group.items.length;
+
+      if (
+        sourceGroupId === targetGroupId &&
+        removedIndex !== null &&
+        removedIndex < insertAt
+      ) {
+        insertAt -= 1;
+      }
+
+      insertAt = Math.max(0, Math.min(insertAt, group.items.length));
+      group.items.splice(insertAt, 0, movingItem!);
+      inserted = true;
+    });
+
+    if (!inserted) {
+      this.applyToGroup(this.order.groups, sourceGroupId, (group) => {
+        group.items.splice(removedIndex ?? group.items.length, 0, movingItem!);
+      });
+    }
+
+    this.draggedItem = null;
+  }
+
+  isDraggingItem(itemId: string): boolean {
+    return this.draggedItem?.itemId === itemId;
+  }
+
+  private pruneGroup(groups: StockGroup[], targetId: string): StockGroup[] {
+    return groups
+      .filter((group) => group.id !== targetId)
+      .map((group) => ({
+        ...group,
+        groups: this.pruneGroup(group.groups, targetId),
+      }));
+  }
+
   private applyToGroup(
     groups: StockGroup[],
     targetId: string,
@@ -226,21 +328,33 @@ export class SalesOrderDetailComponent implements OnInit, OnDestroy {
     item.billableDays = parsed > 0 ? parsed : undefined;
   }
 
-  setItemDiscountType(item: StockItem, discountType: Discount['type'] | '') {
-    if (!discountType) {
-      item.discount = undefined;
-      return;
-    }
-    item.discount = item.discount ?? { type: discountType, value: 0 };
-    item.discount.type = discountType;
+  updateItemDiscountInput(item: StockItem, value: string) {
+    const parsed = this.parseDiscount(value);
+    item.discount = parsed;
   }
 
-  updateItemDiscountValue(item: StockItem, value: number) {
-    if (!item.discount) {
-      item.discount = { type: 'percent', value };
-      return;
-    }
-    item.discount.value = value;
+  updateGlobalDiscountInput(value: string) {
+    if (!this.order) return;
+    this.order.globalDiscount = this.parseDiscount(value);
+  }
+
+  formatDiscount(discount?: Discount | null): string {
+    if (!discount) return '';
+    return discount.type === 'percent'
+      ? `${discount.value || 0}%`
+      : `$${discount.value || 0}`;
+  }
+
+  private parseDiscount(value: string): Discount | undefined {
+    const raw = (value || '').trim();
+    if (!raw) return undefined;
+
+    const isPercent = raw.includes('%');
+    const numeric = parseFloat(raw.replace(/[^0-9.]/g, '')) || 0;
+
+    return isPercent
+      ? { type: 'percent', value: numeric }
+      : { type: 'amount', value: numeric };
   }
 
   updateOrder() {
@@ -322,8 +436,9 @@ export class SalesOrderDetailComponent implements OnInit, OnDestroy {
 
     if (section === 'financial') {
       this.draftFinancial = {
-        globalDiscountType: this.order.globalDiscount?.type || 'percent',
-        globalDiscountValue: this.order.globalDiscount?.value || 0,
+        discount: this.order.globalDiscount
+          ? { ...this.order.globalDiscount }
+          : { type: 'percent', value: 0 },
         customerReference: this.order.customerReference,
         totalDiscount: this.order.totalDiscount,
       };
@@ -361,12 +476,19 @@ export class SalesOrderDetailComponent implements OnInit, OnDestroy {
 
   saveFinancial() {
     if (!this.order) return;
-    this.order.globalDiscount = {
-      type: this.draftFinancial.globalDiscountType,
-      value: Number(this.draftFinancial.globalDiscountValue) || 0,
-    };
+    this.order.globalDiscount = this.draftFinancial.discount
+      ? { ...this.draftFinancial.discount }
+      : undefined;
     this.order.customerReference = this.draftFinancial.customerReference;
     this.order.totalDiscount = Number(this.draftFinancial.totalDiscount) || 0;
     this.closeEdit();
+  }
+
+  formatDiscountDraft(): string {
+    return this.formatDiscount(this.draftFinancial.discount);
+  }
+
+  updateDraftFinancialDiscount(value: string) {
+    this.draftFinancial.discount = this.parseDiscount(value);
   }
 }


### PR DESCRIPTION
## Summary
- inline item SKUs with titles and streamline discount inputs that auto-detect percent vs amount
- remove manual save and financial edit controls while autosaving when leaving the page
- soften subgroup visuals to show indentation without nested boxes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e89b100fc83239db93c2b0cdc49c0)