### PR TITLE
Add purchase order management feature

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -157,6 +157,15 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'purchase-orders',
+    loadComponent: () =>
+      import('./purchasing/purchase-orders.component').then(
+        (m) => m.PurchaseOrdersComponent,
+      ),
+    title: 'Purchase Orders | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
     path: 'settings',
     loadComponent: () =>
       import('./settings/settings-dashboard/settings-dashboard.component').then(

--- a/src/app/purchasing/purchase-orders.component.html
+++ b/src/app/purchasing/purchase-orders.component.html
@@ -1,0 +1,216 @@
+<ui-shell>
+  <content class="po-content">
+    <div class="po-header">
+      <div>
+        <p class="eyebrow">Procurement</p>
+        <h1>Purchase Orders</h1>
+        <p class="subtitle">
+          Track inbound stock, freight, and documents for every purchase order.
+        </p>
+      </div>
+      <div class="actions">
+        <label class="inline-control">
+          <span>View archived</span>
+          <input type="checkbox" [(ngModel)]="showArchived" />
+        </label>
+        <button class="primary" type="button" (click)="openCreateModal()">
+          + New purchase order
+        </button>
+      </div>
+    </div>
+
+    <div class="table-wrapper" *ngIf="displayedOrders.length; else emptyState">
+      <table>
+        <thead>
+          <tr>
+            <th>PO #</th>
+            <th>Vendor</th>
+            <th>Recipient branch</th>
+            <th>Created</th>
+            <th>Expected arrival</th>
+            <th>Status</th>
+            <th>Tracking</th>
+            <th>Total</th>
+            <th>Exports</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let order of displayedOrders">
+            <td>{{ order.poNumber }}</td>
+            <td>{{ order.vendor }}</td>
+            <td>
+              <div class="stacked">
+                <span>{{ order.recipientBranch }}</span>
+                <small>{{ order.deliveryAddress }}</small>
+              </div>
+            </td>
+            <td>{{ order.createdOn | date: 'dd MMM yyyy' }}</td>
+            <td>{{ order.expectedArrival | date: 'dd MMM yyyy' }}</td>
+            <td>
+              <select [ngModel]="order.status" (ngModelChange)="changeStatus(order, $event)">
+                <option value="Ordered">Ordered</option>
+                <option value="Shipping">Shipping</option>
+                <option value="Shipped">Shipped</option>
+                <option value="Received">Received</option>
+                <option value="Cancelled">Cancelled</option>
+              </select>
+            </td>
+            <td>
+              <div class="stacked">
+                <span *ngIf="order.trackingNumber; else noTracking">
+                  {{ order.carrier || 'Carrier TBC' }} · {{ order.trackingNumber }}
+                </span>
+                <ng-template #noTracking>
+                  <small>Tracking not provided</small>
+                </ng-template>
+                <small>Arrival: {{ order.expectedArrival | date: 'dd MMM' }}</small>
+              </div>
+            </td>
+            <td>{{ totalFor(order) | currency:'NZD':'symbol':'1.0-0' }}</td>
+            <td class="export-actions">
+              <button type="button" class="ghost" (click)="export(order, 'rfq')">RFQ</button>
+              <button type="button" class="ghost" (click)="export(order, 'po')">PO</button>
+              <button type="button" class="ghost" (click)="export(order, 'delivery')">Docket</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <ng-template #emptyState>
+      <div class="empty-state">
+        <p>No purchase orders in this view yet.</p>
+      </div>
+    </ng-template>
+
+    <div
+      class="modal-backdrop"
+      *ngIf="creationModalOpen"
+      (click)="closeCreateModal()"
+    >
+      <div class="modal" (click)="$event.stopPropagation()">
+        <header class="modal__header">
+          <div>
+            <p class="eyebrow">Create order</p>
+            <h2>New purchase order</h2>
+          </div>
+          <button
+            type="button"
+            class="modal__close"
+            aria-label="Close create form"
+            (click)="closeCreateModal()"
+          >
+            ×
+          </button>
+        </header>
+
+        <div class="modal__body">
+          <div class="grid two">
+            <label>
+              <span>Vendor</span>
+              <input type="text" [(ngModel)]="newOrder.vendor" placeholder="Supplier name" />
+            </label>
+            <label>
+              <span>Recipient branch</span>
+              <select [(ngModel)]="newOrder.recipientBranch" (change)="updateBranch(newOrder.recipientBranch)">
+                <option *ngFor="let branch of branches" [value]="branch">{{ branch }}</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="grid two">
+            <label>
+              <span>Delivery contact</span>
+              <input type="text" [(ngModel)]="newOrder.deliveryContact" />
+            </label>
+            <label>
+              <span>Delivery address</span>
+              <input type="text" [(ngModel)]="newOrder.deliveryAddress" />
+            </label>
+          </div>
+
+          <div class="grid three">
+            <label>
+              <span>Expected arrival</span>
+              <input type="date" [(ngModel)]="newOrder.expectedArrival" />
+            </label>
+            <label>
+              <span>Tracking number</span>
+              <input type="text" [(ngModel)]="newOrder.trackingNumber" placeholder="Optional" />
+            </label>
+            <label>
+              <span>Carrier</span>
+              <select [(ngModel)]="newOrder.carrier">
+                <option [ngValue]="undefined">Select carrier</option>
+                <option *ngFor="let carrier of carriers" [ngValue]="carrier">{{ carrier }}</option>
+              </select>
+            </label>
+          </div>
+
+          <div class="grid two">
+            <label>
+              <span>Status</span>
+              <select [(ngModel)]="creationStatus">
+                <option value="Ordered">Ordered</option>
+                <option value="Shipping">Shipping</option>
+                <option value="Shipped">Shipped</option>
+                <option value="Received">Received</option>
+                <option value="Cancelled">Cancelled</option>
+              </select>
+            </label>
+            <label>
+              <span>Branch (for reference)</span>
+              <input type="text" [(ngModel)]="newOrder.branch" />
+            </label>
+          </div>
+
+          <h3>Items</h3>
+          <div class="line-items">
+            <div class="line-item" *ngFor="let item of newOrder.items; let i = index">
+              <div class="line-item__main">
+                <input
+                  type="text"
+                  [(ngModel)]="item.description"
+                  (input)="searchInventory(item)"
+                  placeholder="Type to search inventory or add free-text"
+                />
+                <div class="suggestions" *ngIf="item.suggestions?.length">
+                  <button
+                    type="button"
+                    *ngFor="let suggestion of item.suggestions"
+                    (click)="applySuggestion(item, suggestion)"
+                  >
+                    {{ suggestion.description }} ({{ suggestion.sku }}) · {{ suggestion.price | currency:'NZD':'symbol':'1.0-0' }}
+                  </button>
+                  <button type="button" class="ghost" (click)="clearSuggestions(item)">
+                    Hide suggestions
+                  </button>
+                </div>
+              </div>
+              <input type="number" min="1" [(ngModel)]="item.quantity" />
+              <input type="number" min="0" step="0.01" [(ngModel)]="item.price" />
+              <span class="line-item__total">{{ item.quantity * item.price | currency:'NZD':'symbol':'1.0-0' }}</span>
+              <button type="button" class="ghost" (click)="removeLineItem(i)" aria-label="Remove line">✕</button>
+            </div>
+          </div>
+          <button class="secondary" type="button" (click)="addLineItem()">+ Add another item</button>
+        </div>
+
+        <footer class="modal__actions">
+          <div class="summary">
+            <p>PO total</p>
+            <strong>{{ newOrder.items.reduce((sum, item) => sum + item.quantity * item.price, 0) | currency:'NZD':'symbol':'1.0-0' }}</strong>
+          </div>
+          <div class="modal__actions-buttons">
+            <button type="button" class="secondary" (click)="closeCreateModal()">
+              Cancel
+            </button>
+            <button type="button" class="primary" (click)="createOrder()">
+              Create purchase order
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  </content>
+</ui-shell>

--- a/src/app/purchasing/purchase-orders.component.scss
+++ b/src/app/purchasing/purchase-orders.component.scss
@@ -1,0 +1,239 @@
+.po-content {
+  display: block;
+  padding: 24px 32px;
+}
+
+.po-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 24px;
+
+  .actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+  }
+}
+
+.subtitle {
+  color: #4a5568;
+  margin-top: 4px;
+}
+
+.inline-control {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 14px;
+}
+
+.table-wrapper {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 12px 14px;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+  }
+
+  th {
+    background: #f8fafc;
+    font-weight: 600;
+    font-size: 14px;
+  }
+
+  td select,
+  td input[type='number'] {
+    width: 100%;
+  }
+}
+
+.stacked {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.empty-state {
+  padding: 32px;
+  text-align: center;
+  color: #4a5568;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.32);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 50;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  width: min(960px, 100%);
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.12);
+}
+
+.modal__header,
+.modal__actions {
+  padding: 20px 24px;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.modal__actions {
+  border-bottom: none;
+  border-top: 1px solid #e2e8f0;
+}
+
+.modal__body {
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+
+  &.two {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  &.three {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  color: #2d3748;
+
+  input,
+  select,
+  textarea {
+    border: 1px solid #cbd5e0;
+    border-radius: 6px;
+    padding: 10px 12px;
+    font-weight: 500;
+  }
+}
+
+.line-items {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.line-item {
+  display: grid;
+  grid-template-columns: 1.4fr 0.4fr 0.4fr auto auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.line-item__main {
+  position: relative;
+}
+
+.suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #cbd5e0;
+  border-radius: 8px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  z-index: 10;
+
+  button {
+    width: 100%;
+    text-align: left;
+  }
+}
+
+.line-item__total {
+  font-weight: 700;
+}
+
+.modal__actions-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.export-actions {
+  display: flex;
+  gap: 4px;
+}
+
+button.ghost {
+  background: transparent;
+  border: 1px solid #cbd5e0;
+  padding: 6px 10px;
+  border-radius: 6px;
+}
+
+button.secondary {
+  background: #fff;
+  border: 1px solid #3182ce;
+  color: #2b6cb0;
+}
+
+button.primary {
+  background: #2b6cb0;
+  border: none;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #718096;
+  font-size: 12px;
+  margin: 0;
+}

--- a/src/app/purchasing/purchase-orders.component.ts
+++ b/src/app/purchasing/purchase-orders.component.ts
@@ -1,0 +1,205 @@
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { UiShellComponent } from '../shared/ui-shell/ui-shell-component';
+import {
+  FreightCarrier,
+  PurchaseOrder,
+  PurchaseOrderItem,
+  PurchaseOrderStatus,
+  PurchaseOrdersService,
+} from './purchase-orders.service';
+import { Subscription } from 'rxjs';
+
+interface DraftItem extends PurchaseOrderItem {
+  suggestionTerm?: string;
+  suggestions?: { description: string; sku: string; price: number }[];
+}
+
+@Component({
+  selector: 'app-purchase-orders',
+  standalone: true,
+  imports: [UiShellComponent, CommonModule, FormsModule, DatePipe, CurrencyPipe],
+  templateUrl: './purchase-orders.component.html',
+  styleUrl: './purchase-orders.component.scss',
+})
+export class PurchaseOrdersComponent implements OnInit, OnDestroy {
+  activeOrders: PurchaseOrder[] = [];
+  archivedOrders: PurchaseOrder[] = [];
+  showArchived = false;
+
+  creationModalOpen = false;
+  creationStatus: PurchaseOrderStatus = 'Ordered';
+  carriers: FreightCarrier[] = [
+    'NZPost',
+    'Mainfreight',
+    'FedEx',
+    'DHL',
+    'Mainstream',
+    'Team Global Express',
+    'NZ Couriers',
+    'Posthaste',
+  ];
+
+  newOrder = this.blankOrder();
+
+  private readonly subscriptions: Subscription[] = [];
+
+  constructor(private readonly purchaseOrdersService: PurchaseOrdersService) {}
+
+  ngOnInit(): void {
+    this.subscriptions.push(
+      this.purchaseOrdersService.orders$.subscribe((orders) => {
+        this.activeOrders = this.purchaseOrdersService.activeOrders;
+        this.archivedOrders = this.purchaseOrdersService.archivedOrders;
+      }),
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+  }
+
+  get displayedOrders(): PurchaseOrder[] {
+    return this.showArchived ? this.archivedOrders : this.activeOrders;
+  }
+
+  get branches(): string[] {
+    return this.purchaseOrdersService.getBranches().map((branch) => branch.name);
+  }
+
+  openCreateModal() {
+    this.newOrder = this.blankOrder();
+    this.creationModalOpen = true;
+  }
+
+  closeCreateModal() {
+    this.creationModalOpen = false;
+  }
+
+  addLineItem() {
+    this.newOrder.items.push({
+      id: crypto.randomUUID(),
+      description: '',
+      quantity: 1,
+      price: 0,
+      suggestionTerm: '',
+      suggestions: [],
+    });
+  }
+
+  removeLineItem(index: number) {
+    this.newOrder.items.splice(index, 1);
+  }
+
+  updateBranch(branch: string) {
+    const profile = this.purchaseOrdersService.findBranchProfile(branch);
+    this.newOrder.recipientBranch = branch;
+    this.newOrder.branch = branch;
+    this.newOrder.deliveryAddress = profile.address;
+    this.newOrder.deliveryContact = profile.contact;
+  }
+
+  searchInventory(item: DraftItem) {
+    item.suggestions = this.purchaseOrdersService
+      .findInventoryMatches(item.description)
+      .map((match) => ({
+        description: match.name,
+        sku: match.sku,
+        price: match.productCost,
+      }));
+  }
+
+  applySuggestion(item: DraftItem, suggestion: { description: string; sku: string; price: number }) {
+    item.description = suggestion.description;
+    item.sku = suggestion.sku;
+    item.price = suggestion.price;
+    item.suggestions = [];
+  }
+
+  clearSuggestions(item: DraftItem) {
+    item.suggestions = [];
+  }
+
+  createOrder() {
+    if (!this.newOrder.vendor.trim()) return;
+    if (!this.newOrder.items.length) return;
+
+    const payloadItems = this.newOrder.items.map((item) => ({
+      id: item.id,
+      description: item.description,
+      quantity: item.quantity,
+      price: item.price,
+      sku: item.sku,
+    }));
+
+    const created = this.purchaseOrdersService.createOrder({
+      vendor: this.newOrder.vendor,
+      branch: this.newOrder.branch,
+      recipientBranch: this.newOrder.recipientBranch,
+      deliveryContact: this.newOrder.deliveryContact,
+      deliveryAddress: this.newOrder.deliveryAddress,
+      expectedArrival: this.newOrder.expectedArrival,
+      trackingNumber: this.newOrder.trackingNumber,
+      carrier: this.newOrder.carrier,
+      status: this.creationStatus,
+      items: payloadItems,
+    });
+
+    this.closeCreateModal();
+    this.showArchived = false;
+    this.creationStatus = 'Ordered';
+    this.newOrder = this.blankOrder(created.createdOn);
+  }
+
+  changeStatus(order: PurchaseOrder, status: PurchaseOrderStatus) {
+    this.purchaseOrdersService.updateOrderStatus(order.id, status);
+  }
+
+  totalFor(order: PurchaseOrder): number {
+    return this.purchaseOrdersService.calculateTotal(order);
+  }
+
+  export(order: PurchaseOrder, type: 'rfq' | 'po' | 'delivery') {
+    const text = this.purchaseOrdersService.exportDocument(order, type);
+    const blob = new Blob([text], { type: 'text/plain' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `${order.poNumber}-${type}.txt`;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  }
+
+  private blankOrder(createdOn?: string) {
+    const today = createdOn ?? new Date().toISOString().slice(0, 10);
+    const defaultArrival = new Date(today);
+    defaultArrival.setDate(defaultArrival.getDate() + 7);
+    const profile = this.purchaseOrdersService.findBranchProfile('Christchurch');
+
+    const draft: PurchaseOrder & { items: DraftItem[] } = {
+      id: '',
+      poNumber: '',
+      vendor: '',
+      branch: profile.name,
+      recipientBranch: profile.name,
+      deliveryContact: profile.contact,
+      deliveryAddress: profile.address,
+      status: 'Ordered',
+      trackingNumber: '',
+      carrier: undefined,
+      expectedArrival: defaultArrival.toISOString().slice(0, 10),
+      createdOn: today,
+      items: [
+        {
+          id: crypto.randomUUID(),
+          description: '',
+          quantity: 1,
+          price: 0,
+          suggestions: [],
+        },
+      ],
+    };
+
+    return draft;
+  }
+}

--- a/src/app/purchasing/purchase-orders.service.ts
+++ b/src/app/purchasing/purchase-orders.service.ts
@@ -1,0 +1,287 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { InventoryService } from '../inventory/inventory.service';
+import { InventoryItem } from '../shared/models-and-mappers/item/item-model';
+import { PreferencesService } from '../shared/preferences/preferences.service';
+
+export type PurchaseOrderStatus =
+  | 'Ordered'
+  | 'Shipping'
+  | 'Shipped'
+  | 'Received'
+  | 'Cancelled';
+
+export type FreightCarrier =
+  | 'NZPost'
+  | 'Mainfreight'
+  | 'FedEx'
+  | 'DHL'
+  | 'Mainstream'
+  | 'Team Global Express'
+  | 'NZ Couriers'
+  | 'Posthaste';
+
+export interface PurchaseOrderItem {
+  id: string;
+  description: string;
+  sku?: string;
+  quantity: number;
+  price: number;
+}
+
+export interface PurchaseOrder {
+  id: string;
+  poNumber: string;
+  vendor: string;
+  branch: string;
+  deliveryContact: string;
+  deliveryAddress: string;
+  recipientBranch: string;
+  status: PurchaseOrderStatus;
+  trackingNumber?: string;
+  carrier?: FreightCarrier;
+  expectedArrival: string;
+  createdOn: string;
+  items: PurchaseOrderItem[];
+}
+
+export interface BranchDeliveryProfile {
+  name: string;
+  contact: string;
+  address: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PurchaseOrdersService {
+  private readonly branchProfiles: BranchDeliveryProfile[] = [
+    {
+      name: 'Christchurch',
+      contact: 'Ops Desk · 03 555 0101',
+      address: '61 Lichfield Street, Christchurch 8011',
+    },
+    {
+      name: 'Dunedin',
+      contact: 'Warehouse · 03 555 0145',
+      address: '4 Wharf Street, Dunedin 9016',
+    },
+    {
+      name: 'Auckland',
+      contact: 'Freight Inwards · 09 555 0110',
+      address: '120 Fanshawe Street, Auckland 1010',
+    },
+  ];
+
+  private readonly ordersSubject = new BehaviorSubject<PurchaseOrder[]>([
+    {
+      id: 'po-001',
+      poNumber: 'PO-2401',
+      vendor: 'ACME Rigging Supplies',
+      branch: 'Christchurch',
+      recipientBranch: 'Christchurch',
+      deliveryContact: 'Ops Desk · 03 555 0101',
+      deliveryAddress: '61 Lichfield Street, Christchurch 8011',
+      status: 'Shipping',
+      carrier: 'Mainfreight',
+      trackingNumber: 'MNF123456789',
+      createdOn: '2024-08-18',
+      expectedArrival: this.addDays('2024-08-18', 7),
+      items: [
+        {
+          id: 'po-001-1',
+          description: '12m Truss Length',
+          sku: '564209',
+          quantity: 12,
+          price: 430,
+        },
+        {
+          id: 'po-001-2',
+          description: 'Chain Motor 1T',
+          quantity: 8,
+          price: 1250,
+        },
+      ],
+    },
+    {
+      id: 'po-002',
+      poNumber: 'PO-2402',
+      vendor: 'Southern Audio Ltd',
+      branch: 'Dunedin',
+      recipientBranch: 'Dunedin',
+      deliveryContact: 'Warehouse · 03 555 0145',
+      deliveryAddress: '4 Wharf Street, Dunedin 9016',
+      status: 'Received',
+      carrier: 'NZPost',
+      trackingNumber: 'NZP77881234',
+      createdOn: '2024-08-01',
+      expectedArrival: '2024-08-08',
+      items: [
+        {
+          id: 'po-002-1',
+          description: 'Shure SM58',
+          sku: '843512',
+          quantity: 24,
+          price: 120,
+        },
+      ],
+    },
+    {
+      id: 'po-003',
+      poNumber: 'GRAV-PO-2403',
+      vendor: 'Global Freight Partners',
+      branch: 'Auckland',
+      recipientBranch: 'Auckland',
+      deliveryContact: 'Freight Inwards · 09 555 0110',
+      deliveryAddress: '120 Fanshawe Street, Auckland 1010',
+      status: 'Ordered',
+      carrier: 'DHL',
+      trackingNumber: 'DHL00997311',
+      createdOn: '2024-08-20',
+      expectedArrival: this.addDays('2024-08-20', 10),
+      items: [
+        {
+          id: 'po-003-1',
+          description: 'LED Fresnel 300W',
+          sku: '192176',
+          quantity: 20,
+          price: 900,
+        },
+      ],
+    },
+  ]);
+
+  readonly orders$ = this.ordersSubject.asObservable();
+
+  constructor(
+    private readonly inventoryService: InventoryService,
+    private readonly preferencesService: PreferencesService,
+  ) {}
+
+  get orders(): PurchaseOrder[] {
+    return this.ordersSubject.getValue();
+  }
+
+  get activeOrders(): PurchaseOrder[] {
+    return this.orders.filter((order) => !this.isArchived(order));
+  }
+
+  get archivedOrders(): PurchaseOrder[] {
+    return this.orders.filter((order) => this.isArchived(order));
+  }
+
+  getBranches(): BranchDeliveryProfile[] {
+    return this.branchProfiles;
+  }
+
+  findBranchProfile(branch: string): BranchDeliveryProfile {
+    return (
+      this.branchProfiles.find((profile) => profile.name === branch) ||
+      this.branchProfiles[0]
+    );
+  }
+
+  findInventoryMatches(term: string): InventoryItem[] {
+    const normalised = term.trim().toLowerCase();
+    if (!normalised) return [];
+
+    return this.inventoryService
+      .list()
+      .filter((item) =>
+        [item.name, item.sku].some((field) =>
+          field.toLowerCase().includes(normalised),
+        ),
+      )
+      .slice(0, 5);
+  }
+
+  createOrder(payload: {
+    vendor: string;
+    branch: string;
+    recipientBranch: string;
+    deliveryContact: string;
+    deliveryAddress: string;
+    expectedArrival: string;
+    status: PurchaseOrderStatus;
+    trackingNumber?: string;
+    carrier?: FreightCarrier;
+    items: PurchaseOrderItem[];
+  }): PurchaseOrder {
+    const createdOn = new Date().toISOString().slice(0, 10);
+    const poNumber = this.generatePoNumber();
+    const order: PurchaseOrder = {
+      id: crypto.randomUUID(),
+      poNumber,
+      vendor: payload.vendor || 'Unspecified vendor',
+      branch: payload.branch,
+      recipientBranch: payload.recipientBranch,
+      deliveryContact: payload.deliveryContact,
+      deliveryAddress: payload.deliveryAddress,
+      status: payload.status,
+      trackingNumber: payload.trackingNumber,
+      carrier: payload.carrier,
+      createdOn,
+      expectedArrival: payload.expectedArrival,
+      items: payload.items.map((item) => ({
+        ...item,
+        id: item.id || crypto.randomUUID(),
+      })),
+    };
+
+    this.ordersSubject.next([order, ...this.orders]);
+    return order;
+  }
+
+  updateOrderStatus(id: string, status: PurchaseOrderStatus) {
+    const updated = this.orders.map((order) =>
+      order.id === id ? { ...order, status } : order,
+    );
+    this.ordersSubject.next(updated);
+  }
+
+  exportDocument(
+    order: PurchaseOrder,
+    type: 'rfq' | 'po' | 'delivery',
+  ): string {
+    const titleMap = {
+      rfq: 'Request for Quotation',
+      po: 'Purchase Order',
+      delivery: 'Delivery Docket',
+    } as const;
+
+    const items = order.items
+      .map(
+        (item) =>
+          `- ${item.description} (${item.sku ?? 'no sku'}) ×${item.quantity} @ $${item.price.toFixed(2)}`,
+      )
+      .join('\n');
+
+    return `${titleMap[type]}\nPO: ${order.poNumber}\nVendor: ${order.vendor}\nShip to: ${order.deliveryAddress}\nStatus: ${order.status}\nExpected: ${order.expectedArrival}\nItems:\n${items}\nTotal: $${this.calculateTotal(order).toFixed(2)}`;
+  }
+
+  calculateTotal(order: PurchaseOrder): number {
+    return order.items.reduce(
+      (sum, item) => sum + item.quantity * item.price,
+      0,
+    );
+  }
+
+  isArchived(order: PurchaseOrder): boolean {
+    return order.status === 'Received' || order.status === 'Cancelled';
+  }
+
+  private addDays(date: string, days: number): string {
+    const base = new Date(date);
+    base.setDate(base.getDate() + days);
+    return base.toISOString().slice(0, 10);
+  }
+
+  private generatePoNumber(): string {
+    const prefix = this.preferencesService.getPurchaseOrderPrefix();
+    const numericValues = this.orders
+      .map((order) => Number(order.poNumber.replace(/\D+/g, '')))
+      .filter((num) => !Number.isNaN(num));
+    const nextNumber = numericValues.length
+      ? Math.max(...numericValues) + 1
+      : 2400;
+    return `${prefix}${nextNumber}`;
+  }
+}

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.html
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.html
@@ -62,6 +62,26 @@
             </select>
           </label>
         </div>
+
+        <div class="settings__preferences">
+          <h3>Purchase order numbering</h3>
+          <p class="settings__hint">
+            Configure the prefix used when automatically generating new PO numbers (e.g. GRAV-PO- or PO-).
+          </p>
+          <label>
+            <span>PO prefix</span>
+            <input
+              type="text"
+              [(ngModel)]="poPrefix"
+              (change)="updatePoPrefix()"
+              [disabled]="!canManagePurchasing()"
+            />
+          </label>
+          <p class="settings__status" *ngIf="poPrefixMessage">{{ poPrefixMessage }}</p>
+          <p class="settings__warning" *ngIf="!canManagePurchasing()">
+            You need administrator access (level 3 or higher) to change the prefix.
+          </p>
+        </div>
       </section>
 
       <section class="settings__panel" *ngIf="activeSection === 'add-user'">

--- a/src/app/settings/settings-dashboard/settings-dashboard.component.ts
+++ b/src/app/settings/settings-dashboard/settings-dashboard.component.ts
@@ -56,6 +56,8 @@ export class SettingsDashboardComponent implements OnInit {
   protected organisationBranding: OrganisationBranding | null = null;
   protected warehouses: string[] = [];
   protected defaultWarehouse = '';
+  protected poPrefix = '';
+  protected poPrefixMessage = '';
   compareLevels = (a: PermissionLevel, b: PermissionLevel) => a === b;
 
   async ngOnInit(): Promise<void> {
@@ -65,6 +67,7 @@ export class SettingsDashboardComponent implements OnInit {
     this.warehouses = this.inventoryService.getWarehouses();
     this.defaultWarehouse =
       this.preferencesService.getDefaultWarehouse() || this.warehouses[0];
+    this.poPrefix = this.preferencesService.getPurchaseOrderPrefix();
   }
 
   protected switchSection(section: 'profile' | 'add-user'): void {
@@ -79,6 +82,21 @@ export class SettingsDashboardComponent implements OnInit {
   protected updateDefaultWarehouse(): void {
     if (!this.defaultWarehouse) return;
     this.preferencesService.setDefaultWarehouse(this.defaultWarehouse);
+  }
+
+  protected updatePoPrefix(): void {
+    if (!this.canManagePurchasing()) {
+      this.poPrefixMessage =
+        'Only administrators can change purchase order numbering.';
+      return;
+    }
+
+    this.preferencesService.setPurchaseOrderPrefix(this.poPrefix);
+    this.poPrefixMessage = `Prefix saved as "${this.poPrefix}".`;
+  }
+
+  protected canManagePurchasing(): boolean {
+    return this.authService.hasPermission(PermissionLevel.Administrator);
   }
 
   protected readonly visiblePermissionLevels$ = this.user$.pipe(

--- a/src/app/shared/main-navigation-component/main-navigation-component.ts
+++ b/src/app/shared/main-navigation-component/main-navigation-component.ts
@@ -78,12 +78,14 @@ export class MainNavigationComponent implements OnInit {
       this.navItems = [
         ...flattened,
         { label: 'Customers', path: '/customers' },
+        { label: 'Purchase Orders', path: '/purchase-orders' },
         this.createToolsNavigation(),
       ];
     } catch (error) {
       console.error('Failed to load navigation items', error);
       this.navItems = [
         { label: 'Customers', path: '/customers' },
+        { label: 'Purchase Orders', path: '/purchase-orders' },
         this.createToolsNavigation(),
       ];
     }

--- a/src/app/shared/preferences/preferences.service.ts
+++ b/src/app/shared/preferences/preferences.service.ts
@@ -6,11 +6,17 @@ import { BehaviorSubject } from 'rxjs';
 export class PreferencesService {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly storageKey = 'cue-rms:defaultWarehouse';
+  private readonly poPrefixKey = 'cue-rms:po-prefix';
 
   private readonly defaultWarehouseSubject = new BehaviorSubject<string>(
     this.readDefaultWarehouse(),
   );
   readonly defaultWarehouse$ = this.defaultWarehouseSubject.asObservable();
+
+  private readonly poPrefixSubject = new BehaviorSubject<string>(
+    this.readPurchaseOrderPrefix(),
+  );
+  readonly poPrefix$ = this.poPrefixSubject.asObservable();
 
   setDefaultWarehouse(warehouse: string) {
     this.defaultWarehouseSubject.next(warehouse);
@@ -19,6 +25,16 @@ export class PreferencesService {
 
   getDefaultWarehouse(): string {
     return this.defaultWarehouseSubject.getValue();
+  }
+
+  setPurchaseOrderPrefix(prefix: string) {
+    const sanitized = prefix?.trim() || 'PO-';
+    this.poPrefixSubject.next(sanitized);
+    this.writePurchaseOrderPrefix(sanitized);
+  }
+
+  getPurchaseOrderPrefix(): string {
+    return this.poPrefixSubject.getValue();
   }
 
   private readDefaultWarehouse(): string {
@@ -37,6 +53,25 @@ export class PreferencesService {
       localStorage.setItem(this.storageKey, warehouse);
     } catch (err) {
       console.warn('Unable to persist default warehouse preference', err);
+    }
+  }
+
+  private readPurchaseOrderPrefix(): string {
+    if (!isPlatformBrowser(this.platformId)) return 'PO-';
+    try {
+      return localStorage.getItem(this.poPrefixKey) || 'PO-';
+    } catch (err) {
+      console.warn('Unable to read purchase order prefix preference', err);
+      return 'PO-';
+    }
+  }
+
+  private writePurchaseOrderPrefix(prefix: string) {
+    if (!isPlatformBrowser(this.platformId)) return;
+    try {
+      localStorage.setItem(this.poPrefixKey, prefix);
+    } catch (err) {
+      console.warn('Unable to persist purchase order prefix', err);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add purchase order list with status updates, tracking info, and export actions
- implement purchase order creation with inventory suggestions, auto-numbering, and branch delivery defaults
- surface purchase orders in navigation and allow admins to configure PO numbering prefix in settings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e91ca01e48323ab11057fbbf7a780)