### PR TITLE
Add crew planner with weekly scheduling and safety alerts

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -94,6 +94,15 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'crew-planner',
+    loadComponent: () =>
+      import('./crew/crew-planner/crew-planner').then(
+        (m) => m.CrewPlannerComponent,
+      ),
+    title: 'Crew Planner | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
     path: 'inventory/:sku/availability',
     loadComponent: () =>
       import(

--- a/src/app/crew/crew-planner/crew-planner.html
+++ b/src/app/crew/crew-planner/crew-planner.html
@@ -1,0 +1,153 @@
+<ui-shell>
+  <content class="crew-planner">
+    <header class="planner-header">
+      <div>
+        <h1>Crew Planner</h1>
+        <p class="helper-text">
+          Week-by-week view of pack-ins, shows, and pack-outs with crew and vehicle checks.
+        </p>
+      </div>
+      <div class="week-controls">
+        <button (click)="prevWeek()">⬅️ Previous</button>
+        <div class="week-range">
+          {{ weekRange.start | date: 'EEE d MMM' }}
+          –
+          {{ weekRange.end | date: 'EEE d MMM' }}
+        </div>
+        <button (click)="nextWeek()">Next ➡️</button>
+      </div>
+    </header>
+
+    <section class="view-mode">
+      <label>
+        <input
+          type="radio"
+          name="mode"
+          value="packInFirst"
+          [(ngModel)]="viewMode"
+        />
+        Group pack-ins first
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="mode"
+          value="chronological"
+          [(ngModel)]="viewMode"
+        />
+        Chronological per day
+      </label>
+    </section>
+
+    <section class="legend">
+      <span class="pill">Pack in</span>
+      <span class="pill pill-show">Show</span>
+      <span class="pill pill-packout">Pack out</span>
+      <span class="pill pill-warning">Crew clash</span>
+      <span class="pill pill-wof">WOF alert</span>
+    </section>
+
+    <div class="week-grid">
+      <div class="day-column" *ngFor="let day of weekDays">
+        <div class="day-header">
+          <div class="day-name">{{ day | date: 'EEEE' }}</div>
+          <div class="day-date">{{ day | date: 'd MMM' }}</div>
+        </div>
+
+        <div class="day-content" *ngIf="getDayBlocks(day).length; else emptyDay">
+          <article
+            class="event"
+            *ngFor="let item of getDayBlocks(day)"
+            [class.production]="item.event.isProduction"
+          >
+            <header class="event-header">
+              <div>
+                <div class="event-title">
+                  <strong>{{ item.event.salesOrder }}</strong>
+                  —
+                  {{ item.event.title }}
+                </div>
+                <div class="event-meta">
+                  {{ typeLabels[item.block.type] }}
+                  •
+                  {{ item.block.start | date: 'shortTime' }}
+                  –
+                  {{ item.block.end | date: 'shortTime' }}
+                </div>
+              </div>
+              <div class="badges">
+                <span class="pill" *ngIf="item.block.type === 'pack_in'">Pack in</span>
+                <span class="pill pill-packout" *ngIf="item.block.type === 'pack_out'">
+                  Pack out
+                </span>
+                <span class="pill pill-show" *ngIf="item.block.type === 'show'">Show</span>
+                <span class="pill pill-production" *ngIf="item.event.isProduction">
+                  Production order
+                </span>
+              </div>
+            </header>
+
+            <div class="event-body">
+              <div class="field">
+                <label>Start</label>
+                <input type="datetime-local" [(ngModel)]="item.block.start" />
+              </div>
+              <div class="field">
+                <label>End</label>
+                <input type="datetime-local" [(ngModel)]="item.block.end" />
+              </div>
+              <div class="field crew">
+                <label>Crew for this block</label>
+                <div class="crew-select">
+                  <select multiple [(ngModel)]="item.block.crewIds">
+                    <option *ngFor="let member of crew" [value]="member.id">
+                      {{ member.name }} ({{ member.role }})
+                    </option>
+                  </select>
+                </div>
+                <div class="conflicts" *ngIf="crewConflicts(item).length">
+                  <span class="pill pill-warning">Crew clash</span>
+                  <span class="conflict-names">
+                    {{ crewConflicts(item).join(', ') }} already allocated elsewhere
+                  </span>
+                </div>
+              </div>
+              <div class="field vehicles">
+                <label>Vehicles</label>
+                <div class="vehicle-list">
+                  <label *ngFor="let vehicle of vehicles" class="vehicle-option">
+                    <input
+                      type="checkbox"
+                      [checked]="item.event.assignedVehicleIds.includes(vehicle.id)"
+                      (change)="toggleVehicle(item.event, vehicle.id)"
+                    />
+                    {{ vehicle.name }}
+                  </label>
+                </div>
+              </div>
+              <div class="field notes">
+                <label>Notes</label>
+                <textarea rows="2" [(ngModel)]="item.event.notes"></textarea>
+              </div>
+            </div>
+
+            <div class="alerts">
+              <div class="alert warning" *ngIf="vehicleStatus(item.event, new Date(item.block.start)).length">
+                <span class="pill pill-wof">WOF alert</span>
+                <ul>
+                  <li *ngFor="let status of vehicleStatus(item.event, new Date(item.block.start))">
+                    {{ status }} (relative to this call)
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <ng-template #emptyDay>
+          <div class="empty">No events scheduled</div>
+        </ng-template>
+      </div>
+    </div>
+  </content>
+</ui-shell>

--- a/src/app/crew/crew-planner/crew-planner.scss
+++ b/src/app/crew/crew-planner/crew-planner.scss
@@ -1,0 +1,224 @@
+.crew-planner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.planner-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.helper-text {
+  color: #4b5563;
+  margin: 0.25rem 0 0;
+}
+
+.week-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.week-controls button {
+  background: #0f172a;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.view-mode {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.legend {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: #e5e7eb;
+  color: #111827;
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.8rem;
+}
+
+.pill-show {
+  background: #e0f2fe;
+  color: #075985;
+}
+
+.pill-packout {
+  background: #fef9c3;
+  color: #713f12;
+}
+
+.pill-warning {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.pill-wof {
+  background: #f3e8ff;
+  color: #6b21a8;
+}
+
+.pill-production {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.week-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.day-column {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.day-header {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f8fafc;
+}
+
+.day-name {
+  font-weight: 600;
+}
+
+.day-date {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.day-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.event {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.event.production {
+  border-color: #bbf7d0;
+  box-shadow: 0 0 0 1px #dcfce7 inset;
+}
+
+.event-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.event-title {
+  font-weight: 600;
+}
+
+.event-meta {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.event-body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.field label {
+  font-size: 0.85rem;
+  color: #374151;
+  font-weight: 600;
+}
+
+.field input,
+.field select,
+.field textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.crew-select select {
+  min-height: 120px;
+}
+
+.vehicle-list {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.vehicle-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.conflicts {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #991b1b;
+  font-size: 0.9rem;
+}
+
+.alerts {
+  margin-top: 0.25rem;
+}
+
+.alert {
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.alert.warning {
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #7f1d1d;
+}
+
+.alert ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.empty {
+  padding: 1rem;
+  color: #9ca3af;
+  text-align: center;
+}

--- a/src/app/crew/crew-planner/crew-planner.ts
+++ b/src/app/crew/crew-planner/crew-planner.ts
@@ -1,0 +1,360 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { UiShellComponent } from '../../shared/ui-shell/ui-shell-component';
+
+interface CrewMember {
+  id: string;
+  name: string;
+  role: string;
+}
+
+interface Vehicle {
+  id: string;
+  name: string;
+  wofExpiry: string; // ISO date
+}
+
+interface CrewBlock {
+  id: string;
+  type: 'pack_in' | 'pack_out' | 'show';
+  label: string;
+  start: string; // ISO date-time
+  end: string; // ISO date-time
+  crewIds: string[];
+  notes?: string;
+}
+
+interface CrewEvent {
+  id: string;
+  salesOrder: string;
+  title: string;
+  isProduction: boolean;
+  assignedVehicleIds: string[];
+  notes?: string;
+  blocks: CrewBlock[];
+}
+
+interface DayBlock {
+  event: CrewEvent;
+  block: CrewBlock;
+}
+
+@Component({
+  selector: 'crew-planner',
+  standalone: true,
+  imports: [CommonModule, FormsModule, UiShellComponent],
+  templateUrl: './crew-planner.html',
+  styleUrl: './crew-planner.scss',
+})
+export class CrewPlannerComponent {
+  viewMode: 'packInFirst' | 'chronological' = 'packInFirst';
+  weekOffset = 0;
+  weekRange!: { start: Date; end: Date };
+  private readonly anchorDate: Date;
+
+  readonly crew: CrewMember[] = [
+    { id: 'crew-alex', name: 'Alex McKay', role: 'Production Manager' },
+    { id: 'crew-sam', name: 'Samira Lee', role: 'Lighting Tech' },
+    { id: 'crew-jo', name: 'Jordan Phelps', role: 'Audio Tech' },
+    { id: 'crew-ty', name: 'Tyla Chen', role: 'Truck Driver' },
+    { id: 'crew-ani', name: 'Anika Roy', role: 'Stagehand' },
+    { id: 'crew-cam', name: 'Cam Hensley', role: 'Rigger' },
+  ];
+
+  readonly vehicles: Vehicle[] = [
+    { id: 'veh-van', name: 'Cue-Go Van', wofExpiry: '2026-04-02' },
+    { id: 'veh-truck', name: '20m3 Truck', wofExpiry: '2026-03-18' },
+    { id: 'veh-hiace', name: 'Hiace', wofExpiry: '2026-03-30' },
+    { id: 'veh-regius', name: 'Regius', wofExpiry: '2026-05-12' },
+  ];
+
+  readonly events: CrewEvent[] = [
+    {
+      id: 'evt-civic-centre',
+      salesOrder: 'SO-4821',
+      title: 'Pack-in for Civic Centre',
+      isProduction: false,
+      assignedVehicleIds: ['veh-van', 'veh-truck'],
+      notes: 'Meet client at loading dock; access via Gate 2.',
+      blocks: [
+        {
+          id: 'evt-civic-centre-packin',
+          type: 'pack_in',
+          label: 'Pack in',
+          start: '2026-03-16T09:00',
+          end: '2026-03-16T13:00',
+          crewIds: ['crew-alex', 'crew-sam', 'crew-ani'],
+        },
+        {
+          id: 'evt-civic-centre-packout',
+          type: 'pack_out',
+          label: 'Pack out',
+          start: '2026-03-20T18:00',
+          end: '2026-03-20T22:00',
+          crewIds: ['crew-sam', 'crew-ani'],
+        },
+      ],
+    },
+    {
+      id: 'evt-production-awards',
+      salesOrder: 'SO-4819',
+      title: 'Production: Regional Awards',
+      isProduction: true,
+      assignedVehicleIds: ['veh-van', 'veh-hiace'],
+      notes: 'Show time locked; client wants extra RF scan.',
+      blocks: [
+        {
+          id: 'evt-production-awards-packin',
+          type: 'pack_in',
+          label: 'Pack in',
+          start: '2026-03-17T07:00',
+          end: '2026-03-17T12:00',
+          crewIds: ['crew-ty', 'crew-ani'],
+        },
+        {
+          id: 'evt-production-awards-show',
+          type: 'show',
+          label: 'Show call',
+          start: '2026-03-19T18:30',
+          end: '2026-03-19T22:30',
+          crewIds: ['crew-alex', 'crew-jo', 'crew-sam'],
+        },
+        {
+          id: 'evt-production-awards-packout',
+          type: 'pack_out',
+          label: 'Pack out',
+          start: '2026-03-20T23:00',
+          end: '2026-03-21T02:00',
+          crewIds: ['crew-ty', 'crew-ani'],
+        },
+      ],
+    },
+    {
+      id: 'evt-arena-rehearsal',
+      salesOrder: 'SO-4824',
+      title: 'Arena Rehearsal & Pack out',
+      isProduction: true,
+      assignedVehicleIds: ['veh-truck'],
+      notes: 'Lighting console swap available in truck.',
+      blocks: [
+        {
+          id: 'evt-arena-rehearsal-packin',
+          type: 'pack_in',
+          label: 'Pack in',
+          start: '2026-03-18T11:00',
+          end: '2026-03-18T15:00',
+          crewIds: ['crew-jo', 'crew-cam'],
+        },
+        {
+          id: 'evt-arena-rehearsal-show',
+          type: 'show',
+          label: 'Show call',
+          start: '2026-03-18T19:00',
+          end: '2026-03-18T22:00',
+          crewIds: ['crew-jo', 'crew-sam'],
+        },
+        {
+          id: 'evt-arena-rehearsal-packout',
+          type: 'pack_out',
+          label: 'Pack out',
+          start: '2026-03-19T08:00',
+          end: '2026-03-19T11:00',
+          crewIds: ['crew-cam', 'crew-ani'],
+        },
+      ],
+    },
+    {
+      id: 'evt-campus-gala',
+      salesOrder: 'SO-4827',
+      title: 'Campus Gala Reception',
+      isProduction: false,
+      assignedVehicleIds: ['veh-regius'],
+      notes: 'Dinner service in ballroom; quiet pack in.',
+      blocks: [
+        {
+          id: 'evt-campus-gala-packin',
+          type: 'pack_in',
+          label: 'Pack in',
+          start: '2026-03-21T09:30',
+          end: '2026-03-21T12:30',
+          crewIds: ['crew-alex', 'crew-ani'],
+        },
+        {
+          id: 'evt-campus-gala-packout',
+          type: 'pack_out',
+          label: 'Pack out',
+          start: '2026-03-22T08:00',
+          end: '2026-03-22T10:30',
+          crewIds: ['crew-ty', 'crew-ani'],
+        },
+      ],
+    },
+  ];
+
+  readonly typeLabels: Record<CrewBlock['type'], string> = {
+    pack_in: 'Pack in',
+    pack_out: 'Pack out',
+    show: 'Show time',
+  };
+
+  constructor() {
+    this.anchorDate = this.computeAnchorDate();
+    this.calculateWeek();
+  }
+
+  getWeekRange(baseDate: Date) {
+    const start = new Date(baseDate);
+    const day = start.getDay();
+    const diff = (day === 0 ? -6 : 1) - day; // align to Monday
+    start.setDate(start.getDate() + diff);
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    end.setHours(23, 59, 59, 999);
+
+    return { start, end };
+  }
+
+  calculateWeek() {
+    const baseDate = new Date(this.anchorDate);
+    baseDate.setDate(this.anchorDate.getDate() + this.weekOffset * 7);
+    this.weekRange = this.getWeekRange(baseDate);
+  }
+
+  prevWeek() {
+    this.weekOffset -= 1;
+    this.calculateWeek();
+  }
+
+  nextWeek() {
+    this.weekOffset += 1;
+    this.calculateWeek();
+  }
+
+  get weekDays(): Date[] {
+    const days: Date[] = [];
+    for (let i = 0; i < 7; i += 1) {
+      const day = new Date(this.weekRange.start);
+      day.setDate(this.weekRange.start.getDate() + i);
+      days.push(day);
+    }
+    return days;
+  }
+
+  private isWithinWeek(date: Date) {
+    return date >= this.weekRange.start && date <= this.weekRange.end;
+  }
+
+  private computeAnchorDate() {
+    const allDates = this.events
+      .flatMap((event) => event.blocks)
+      .map((block) => new Date(block.start).getTime());
+
+    if (!allDates.length) return new Date();
+
+    const earliest = Math.min(...allDates);
+    return new Date(earliest);
+  }
+
+  private flattenBlocks(): DayBlock[] {
+    return this.events
+      .flatMap((event) =>
+        event.blocks.map((block) => ({
+          event,
+          block,
+        })),
+      )
+      .filter(({ block }) => this.isWithinWeek(new Date(block.start)));
+  }
+
+  getDayBlocks(date: Date): DayBlock[] {
+    const target = date.toDateString();
+    const dayBlocks = this.flattenBlocks().filter(
+      ({ block }) => new Date(block.start).toDateString() === target,
+    );
+
+    return this.sortBlocks(dayBlocks);
+  }
+
+  private sortBlocks(blocks: DayBlock[]): DayBlock[] {
+    if (this.viewMode === 'chronological') {
+      return blocks.sort(
+        (a, b) =>
+          new Date(a.block.start).getTime() - new Date(b.block.start).getTime(),
+      );
+    }
+
+    // Pack-in first, then everything else by time
+    const packIns = blocks
+      .filter(({ block }) => block.type === 'pack_in')
+      .sort(
+        (a, b) =>
+          new Date(a.block.start).getTime() - new Date(b.block.start).getTime(),
+      );
+    const others = blocks
+      .filter(({ block }) => block.type !== 'pack_in')
+      .sort(
+        (a, b) =>
+          new Date(a.block.start).getTime() - new Date(b.block.start).getTime(),
+      );
+
+    return [...packIns, ...others];
+  }
+
+  crewConflicts(target: DayBlock): string[] {
+    const conflicts = new Set<string>();
+    const targetStart = new Date(target.block.start).getTime();
+    const targetEnd = new Date(target.block.end).getTime();
+
+    this.flattenBlocks().forEach(({ block, event }) => {
+      if (block.id === target.block.id) return;
+      const start = new Date(block.start).getTime();
+      const end = new Date(block.end).getTime();
+      const overlaps = targetStart < end && start < targetEnd;
+      if (!overlaps) return;
+
+      target.block.crewIds.forEach((crewId) => {
+        if (block.crewIds.includes(crewId) && event.id !== target.event.id) {
+          const name = this.crew.find((c) => c.id === crewId)?.name;
+          if (name) conflicts.add(name);
+        }
+      });
+    });
+
+    return Array.from(conflicts);
+  }
+
+  vehicleStatus(event: CrewEvent, referenceDate: Date) {
+    const statuses = event.assignedVehicleIds.map((vehicleId) => {
+      const vehicle = this.vehicles.find((v) => v.id === vehicleId);
+      if (!vehicle) return null;
+
+      const wofDate = new Date(vehicle.wofExpiry);
+      const daysUntilExpiry = Math.floor(
+        (wofDate.getTime() - referenceDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+
+      if (daysUntilExpiry < 0) {
+        return `${vehicle.name}: WOF expired`;
+      }
+      if (daysUntilExpiry <= 14) {
+        return `${vehicle.name}: WOF expiring in ${daysUntilExpiry} day(s)`;
+      }
+      return null;
+    });
+
+    return statuses.filter((status) => !!status) as string[];
+  }
+
+  toggleVehicle(event: CrewEvent, vehicleId: string) {
+    if (event.assignedVehicleIds.includes(vehicleId)) {
+      event.assignedVehicleIds = event.assignedVehicleIds.filter(
+        (id) => id !== vehicleId,
+      );
+    } else {
+      event.assignedVehicleIds = [...event.assignedVehicleIds, vehicleId];
+    }
+  }
+}

--- a/src/app/shared/main-navigation-component/main-navigation-component.ts
+++ b/src/app/shared/main-navigation-component/main-navigation-component.ts
@@ -126,6 +126,10 @@ export class MainNavigationComponent implements OnInit {
           label: 'Stage Timer',
           path: '/tools/stage-timer',
         },
+        {
+          label: 'Crew Planner',
+          path: '/crew-planner',
+        },
       ],
     };
   }


### PR DESCRIPTION
## Summary
- add a weekly Crew Planner view with pack-in, show, and pack-out blocks per sales order
- surface crew clash warnings, vehicle WOF expiry alerts, and per-block notes and time controls
- wire the planner into routing and navigation for easy access

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e9e8517e48323926de6ffe047c437)