### PR TITLE
Add crew planner weekly view

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -130,6 +130,15 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'crew-planner',
+    loadComponent: () =>
+      import('./crew-planner/crew-planner.component').then(
+        (m) => m.CrewPlannerComponent,
+      ),
+    title: 'Crew Planner | Cue RMS',
+    canActivate: [authGuard],
+  },
+  {
     path: 'reporting',
     loadComponent: () =>
       import('./reporting/reporting-component/reporting-component').then(

--- a/src/app/crew-planner/crew-planner.component.html
+++ b/src/app/crew-planner/crew-planner.component.html
@@ -1,0 +1,112 @@
+<ui-shell>
+  <content class="crew-planner">
+    <header class="crew-planner__header">
+      <div>
+        <p class="eyebrow">Crew planner</p>
+        <h1>Week of {{ weekDays()[0].date | date: 'MMM d' }} -
+          {{ weekDays()[6].date | date: 'MMM d' }}</h1>
+        <p>
+          Allocate crew, vehicles, and timings for each booking. Warnings show overlapping crew
+          or vehicles with expiring warrants.
+        </p>
+      </div>
+      <div class="crew-planner__actions">
+        <div class="button-group">
+          <button type="button" (click)="adjustWeek(-1)">Previous week</button>
+          <button type="button" class="primary" (click)="adjustWeek(1)">Next week</button>
+        </div>
+        <div class="segmented">
+          <button type="button"
+                  [class.active]="viewMode() === 'byTask'"
+                  (click)="toggleView('byTask')">
+            Pack-in view
+          </button>
+          <button type="button"
+                  [class.active]="viewMode() === 'byTime'"
+                  (click)="toggleView('byTime')">
+            Chronological
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <section class="crew-planner__legend">
+      <div>
+        <span class="badge badge--info"></span>
+        <span>Warnings highlight crew overlaps and WOF expiries but do not block scheduling.</span>
+      </div>
+      <div class="legend__hint">
+        <span class="dot dot--packin"></span> Pack in
+        <span class="dot dot--show"></span> Show
+        <span class="dot dot--packout"></span> Pack out
+      </div>
+    </section>
+
+    <div class="week-grid">
+      <section class="day" *ngFor="let day of weekDays()">
+        <header class="day__header">
+          <div>
+            <p class="eyebrow">{{ day.date | date: 'EEEE' }}</p>
+            <h2>{{ day.date | date: 'MMM d' }}</h2>
+          </div>
+          <span class="day__count">{{ eventsForDay(day.date).length }} events</span>
+        </header>
+
+        <div class="day__empty" *ngIf="eventsForDay(day.date).length === 0">
+          <p>No bookings for this day.</p>
+        </div>
+
+        <article class="event" *ngFor="let event of eventsForDay(day.date)">
+          <header class="event__header">
+            <div>
+              <p class="eyebrow">{{ event.salesOrder }} · {{ event.location }}</p>
+              <h3>{{ event.title }}</h3>
+              <div class="event__tags">
+                <span class="badge" [attr.data-type]="event.type">{{ event.type }}</span>
+                <span class="badge badge--outline" *ngFor="let vehicleId of event.vehicles">
+                  {{ getVehicle(vehicleId)?.name }} · {{ getVehicle(vehicleId)?.licensePlate }}
+                </span>
+              </div>
+            </div>
+            <div class="event__notes" *ngIf="event.notes">
+              <p>{{ event.notes }}</p>
+            </div>
+          </header>
+
+          <ul class="event__timeline">
+            <li class="timeline__row" *ngFor="let slot of slotOrder(event.slots)"
+                [attr.data-slot]="slot.key">
+              <div class="timeline__time">
+                <span class="timeline__label">{{ slot.label }}</span>
+                <span class="timeline__value">{{ formattedTime(event.date, slot.start) }}</span>
+              </div>
+              <div class="timeline__crew">
+                <p class="crew-list">
+                  <span *ngFor="let assignment of slot.crew; let last = last">
+                    {{ crewName(assignment.crewId) }}
+                    <ng-container *ngIf="assignment.responsibility">
+                      <span class="muted">({{ assignment.responsibility }})</span>
+                    </ng-container>
+                    <span *ngIf="!last"> • </span>
+                  </span>
+                </p>
+              </div>
+            </li>
+          </ul>
+
+          <div class="event__warnings" *ngIf="warningForEvent(event.id).crewConflicts.length || warningForEvent(event.id).vehicleAlerts.length">
+            <p class="eyebrow">Alerts</p>
+            <ul>
+              <li *ngFor="let warning of warningForEvent(event.id).crewConflicts">
+                <span class="alert alert--crew">Crew overlap · {{ warning }}</span>
+              </li>
+              <li *ngFor="let warning of warningForEvent(event.id).vehicleAlerts">
+                <span class="alert alert--vehicle">Vehicle · {{ warning }}</span>
+              </li>
+            </ul>
+          </div>
+        </article>
+      </section>
+    </div>
+  </content>
+</ui-shell>

--- a/src/app/crew-planner/crew-planner.component.scss
+++ b/src/app/crew-planner/crew-planner.component.scss
@@ -1,0 +1,278 @@
+.crew-planner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.crew-planner__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.crew-planner__header h1 {
+  margin: 0.25rem 0;
+}
+
+.crew-planner__actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.button-group {
+  display: inline-flex;
+  border: 1px solid #e0e4ec;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: #f8fafc;
+}
+
+.button-group button {
+  padding: 0.6rem 0.9rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.button-group button + button {
+  border-left: 1px solid #e0e4ec;
+}
+
+.button-group .primary {
+  background: #3f5dff;
+  color: #fff;
+}
+
+.segmented {
+  display: inline-flex;
+  border: 1px solid #e0e4ec;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.segmented button {
+  border: none;
+  background: transparent;
+  padding: 0.55rem 0.9rem;
+  cursor: pointer;
+}
+
+.segmented button.active {
+  background: #e8ecff;
+  color: #1f3bb3;
+}
+
+.crew-planner__legend {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: #f8fafc;
+  border: 1px solid #e0e4ec;
+  border-radius: 0.75rem;
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.35rem;
+  font-size: 0.75rem;
+  background: #eef2ff;
+  color: #1f3bb3;
+  border: 1px solid transparent;
+}
+
+.badge[data-type='Dry Hire'] {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.badge--outline {
+  background: #fff;
+  border-color: #d6dae5;
+  color: #3c4664;
+}
+
+.badge--info {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: #1f3bb3;
+}
+
+.legend__hint {
+  display: flex;
+  gap: 1rem;
+  color: #6b7280;
+  align-items: center;
+}
+
+.dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  display: inline-block;
+  border-radius: 999px;
+  margin-right: 0.25rem;
+}
+
+.dot--packin { background: #c7d2fe; }
+.dot--show { background: #fef08a; }
+.dot--packout { background: #d9f99d; }
+
+.week-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.day {
+  border: 1px solid #e0e4ec;
+  border-radius: 0.75rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.day__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.day__count {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.day__empty {
+  background: #f8fafc;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  color: #6b7280;
+}
+
+.event {
+  border: 1px solid #e0e4ec;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.event__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.event__notes {
+  background: #f8fafc;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  max-width: 280px;
+}
+
+.event__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.event__timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.timeline__row {
+  border: 1px solid #e0e4ec;
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.timeline__row[data-slot='packIn'] {
+  background: #f4f6ff;
+}
+
+.timeline__row[data-slot='show'] {
+  background: #fffbeb;
+}
+
+.timeline__row[data-slot='packOut'] {
+  background: #f7fee7;
+}
+
+.timeline__time {
+  min-width: 140px;
+}
+
+.timeline__label {
+  display: block;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.timeline__value {
+  font-weight: 600;
+}
+
+.crew-list {
+  margin: 0;
+  color: #111827;
+}
+
+.muted {
+  color: #6b7280;
+}
+
+.event__warnings {
+  border-top: 1px dashed #e0e4ec;
+  padding-top: 0.5rem;
+}
+
+.alert {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.45rem;
+  font-size: 0.9rem;
+}
+
+.alert--crew {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.alert--vehicle {
+  background: #ecfeff;
+  color: #0f172a;
+}
+
+@media (max-width: 900px) {
+  .crew-planner__header {
+    flex-direction: column;
+  }
+
+  .crew-planner__actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .event__header {
+    flex-direction: column;
+  }
+}

--- a/src/app/crew-planner/crew-planner.component.ts
+++ b/src/app/crew-planner/crew-planner.component.ts
@@ -1,0 +1,533 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, signal } from '@angular/core';
+import { UiShellComponent } from '../shared/ui-shell/ui-shell-component';
+
+interface CrewMember {
+  id: string;
+  name: string;
+  role: string;
+}
+
+interface Vehicle {
+  id: string;
+  name: string;
+  licensePlate: string;
+  warrantExpiry: string; // ISO date
+}
+
+interface CrewAssignment {
+  crewId: string;
+  responsibility?: string;
+}
+
+interface PlannerSlot {
+  key: 'packIn' | 'show' | 'packOut' | 'rehearsal';
+  label: string;
+  start: string; // HH:mm
+  durationMinutes: number;
+  crew: CrewAssignment[];
+}
+
+interface PlannerEvent {
+  id: string;
+  salesOrder: string;
+  title: string;
+  location: string;
+  type: 'Production' | 'Dry Hire';
+  dateOffset: number; // days from week start (Mon = 0)
+  notes?: string;
+  vehicles: string[]; // vehicle IDs
+  slots: PlannerSlot[];
+}
+
+interface EventWarnings {
+  crewConflicts: string[];
+  vehicleAlerts: string[];
+}
+
+interface WeekDay {
+  label: string;
+  date: Date;
+}
+
+@Component({
+  selector: 'crew-planner',
+  imports: [CommonModule, UiShellComponent],
+  templateUrl: './crew-planner.component.html',
+  styleUrl: './crew-planner.component.scss',
+})
+export class CrewPlannerComponent {
+  protected readonly crewMembers = signal<CrewMember[]>([
+    { id: 'crew-1', name: 'Abby', role: 'Prod. Manager' },
+    { id: 'crew-2', name: 'Tobin', role: 'Lighting' },
+    { id: 'crew-3', name: 'Pita', role: 'Audio' },
+    { id: 'crew-4', name: 'Liam', role: 'Rigger' },
+    { id: 'crew-5', name: 'Clem', role: 'Driver' },
+    { id: 'crew-6', name: 'Amie', role: 'LX Tech' },
+  ]);
+
+  protected readonly vehicles = signal<Vehicle[]>([
+    {
+      id: 'vehicle-1',
+      name: '26’ Box Truck',
+      licensePlate: 'FTL 327',
+      warrantExpiry: this.addDays(new Date(), 10).toISOString(),
+    },
+    {
+      id: 'vehicle-2',
+      name: 'Sprinter Van',
+      licensePlate: 'HTM 221',
+      warrantExpiry: this.addDays(new Date(), 40).toISOString(),
+    },
+    {
+      id: 'vehicle-3',
+      name: 'Transit',
+      licensePlate: 'HRA 910',
+      warrantExpiry: this.addDays(new Date(), -2).toISOString(),
+    },
+  ]);
+
+  private readonly baseEvents: PlannerEvent[] = [
+    {
+      id: 'event-1',
+      salesOrder: 'SO-3102',
+      title: 'Taco Joy x New World Week',
+      location: 'Auckland CBD',
+      type: 'Production',
+      dateOffset: 0,
+      notes: 'Stair run to stage area — allow extra hands for pack in.',
+      vehicles: ['vehicle-1'],
+      slots: [
+        {
+          key: 'packIn',
+          label: 'Pack in',
+          start: '08:00',
+          durationMinutes: 120,
+          crew: [
+            { crewId: 'crew-1', responsibility: 'Lead' },
+            { crewId: 'crew-4', responsibility: 'Rigging' },
+            { crewId: 'crew-5', responsibility: 'Driver' },
+          ],
+        },
+        {
+          key: 'show',
+          label: 'Show',
+          start: '13:00',
+          durationMinutes: 180,
+          crew: [
+            { crewId: 'crew-1', responsibility: 'Show caller' },
+            { crewId: 'crew-3', responsibility: 'Audio' },
+            { crewId: 'crew-2', responsibility: 'LX' },
+          ],
+        },
+        {
+          key: 'packOut',
+          label: 'Pack out',
+          start: '17:00',
+          durationMinutes: 120,
+          crew: [
+            { crewId: 'crew-2' },
+            { crewId: 'crew-3' },
+            { crewId: 'crew-4' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'event-2',
+      salesOrder: 'SO-3108',
+      title: 'Podcasts on Stage',
+      location: 'The Civic',
+      type: 'Production',
+      dateOffset: 1,
+      notes: 'Mics need AA batteries supplied.',
+      vehicles: ['vehicle-2'],
+      slots: [
+        {
+          key: 'packIn',
+          label: 'Pack in',
+          start: '09:30',
+          durationMinutes: 90,
+          crew: [
+            { crewId: 'crew-1' },
+            { crewId: 'crew-2' },
+          ],
+        },
+        {
+          key: 'show',
+          label: 'Show',
+          start: '11:00',
+          durationMinutes: 120,
+          crew: [
+            { crewId: 'crew-3', responsibility: 'Mix' },
+            { crewId: 'crew-2', responsibility: 'Lighting' },
+          ],
+        },
+        {
+          key: 'packOut',
+          label: 'Pack out',
+          start: '14:00',
+          durationMinutes: 60,
+          crew: [
+            { crewId: 'crew-1' },
+            { crewId: 'crew-3' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'event-3',
+      salesOrder: 'SO-3115',
+      title: 'University Open Day',
+      location: 'Kelburn Campus',
+      type: 'Dry Hire',
+      dateOffset: 3,
+      vehicles: ['vehicle-3'],
+      notes: 'Dry hire — crew on pack in only.',
+      slots: [
+        {
+          key: 'packIn',
+          label: 'Pack in',
+          start: '07:00',
+          durationMinutes: 60,
+          crew: [
+            { crewId: 'crew-5', responsibility: 'Driver' },
+            { crewId: 'crew-6', responsibility: 'Check gear' },
+          ],
+        },
+        {
+          key: 'packOut',
+          label: 'Pack out',
+          start: '18:00',
+          durationMinutes: 60,
+          crew: [{ crewId: 'crew-6' }],
+        },
+      ],
+    },
+    {
+      id: 'event-4',
+      salesOrder: 'SO-3119',
+      title: 'Annual Awards Dinner',
+      location: 'SkyCity Ballroom',
+      type: 'Production',
+      dateOffset: 5,
+      notes: 'Client bringing MC console.',
+      vehicles: ['vehicle-1', 'vehicle-2'],
+      slots: [
+        {
+          key: 'packIn',
+          label: 'Pack in',
+          start: '10:00',
+          durationMinutes: 120,
+          crew: [
+            { crewId: 'crew-1', responsibility: 'Client lead' },
+            { crewId: 'crew-4', responsibility: 'Rigging' },
+            { crewId: 'crew-2', responsibility: 'LX' },
+          ],
+        },
+        {
+          key: 'show',
+          label: 'Show',
+          start: '19:00',
+          durationMinutes: 180,
+          crew: [
+            { crewId: 'crew-1' },
+            { crewId: 'crew-2' },
+            { crewId: 'crew-3', responsibility: 'Audio' },
+          ],
+        },
+        {
+          key: 'packOut',
+          label: 'Pack out',
+          start: '23:00',
+          durationMinutes: 120,
+          crew: [
+            { crewId: 'crew-4' },
+            { crewId: 'crew-5' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'event-5',
+      salesOrder: 'SO-3123',
+      title: 'Town Hall Wedding',
+      location: 'Lower Hutt',
+      type: 'Production',
+      dateOffset: 5,
+      vehicles: ['vehicle-2'],
+      notes: 'Band to arrive 2pm — coordinate with planner.',
+      slots: [
+        {
+          key: 'packIn',
+          label: 'Pack in',
+          start: '12:00',
+          durationMinutes: 120,
+          crew: [
+            { crewId: 'crew-3', responsibility: 'Lead' },
+            { crewId: 'crew-6' },
+          ],
+        },
+        {
+          key: 'show',
+          label: 'Show',
+          start: '16:30',
+          durationMinutes: 180,
+          crew: [
+            { crewId: 'crew-3' },
+            { crewId: 'crew-2' },
+          ],
+        },
+        {
+          key: 'packOut',
+          label: 'Pack out',
+          start: '22:30',
+          durationMinutes: 90,
+          crew: [
+            { crewId: 'crew-3' },
+            { crewId: 'crew-2' },
+          ],
+        },
+      ],
+    },
+  ];
+
+  protected readonly viewMode = signal<'byTask' | 'byTime'>('byTask');
+  protected readonly selectedWeekStart = signal<Date>(
+    this.getStartOfWeek(new Date()),
+  );
+
+  protected readonly weekDays = computed<WeekDay[]>(() => {
+    const start = this.selectedWeekStart();
+    return Array.from({ length: 7 }).map((_, index) => ({
+      date: this.addDays(start, index),
+      label: this.addDays(start, index).toLocaleDateString(undefined, {
+        weekday: 'long',
+        month: 'short',
+        day: 'numeric',
+      }),
+    }));
+  });
+
+  protected readonly plannerEvents = computed<(PlannerEvent & { date: Date })[]>(
+    () =>
+      this.baseEvents.map((event) => ({
+        ...event,
+        date: this.addDays(this.selectedWeekStart(), event.dateOffset),
+      })),
+  );
+
+  protected readonly eventWarnings = computed<Map<string, EventWarnings>>(() => {
+    const warnings = new Map<string, EventWarnings>();
+    const events = this.plannerEvents();
+    events.forEach((event) =>
+      warnings.set(event.id, { crewConflicts: [], vehicleAlerts: [] }),
+    );
+
+    const eventsByDate = new Map<string, PlannerEvent[]>();
+    for (const event of events) {
+      const key = this.formatDateKey(event.date as Date);
+      const collection = eventsByDate.get(key) ?? [];
+      collection.push(event);
+      eventsByDate.set(key, collection);
+    }
+
+    for (const dayEvents of eventsByDate.values()) {
+      this.detectCrewConflicts(dayEvents, warnings);
+    }
+
+    events.forEach((event) => {
+      const vehicleAlerts = warnings.get(event.id)?.vehicleAlerts ?? [];
+      for (const vehicleId of event.vehicles) {
+        const vehicle = this.getVehicle(vehicleId);
+        if (!vehicle) continue;
+        const expiry = new Date(vehicle.warrantExpiry);
+        const eventDate = event.date as Date;
+        if (expiry < eventDate) {
+          vehicleAlerts.push(
+            `${vehicle.name} (${vehicle.licensePlate}) WOF is expired before this event`,
+          );
+        } else {
+          const daysUntilExpiry = Math.round(
+            (expiry.getTime() - eventDate.getTime()) / (1000 * 60 * 60 * 24),
+          );
+          if (daysUntilExpiry <= 30) {
+            vehicleAlerts.push(
+              `${vehicle.name} (${vehicle.licensePlate}) WOF expires in ${daysUntilExpiry} day${
+                daysUntilExpiry === 1 ? '' : 's'
+              }`,
+            );
+          }
+        }
+      }
+    });
+
+    return warnings;
+  });
+
+  protected eventsForDay(day: Date): (PlannerEvent & { date: Date })[] {
+    const key = this.formatDateKey(day);
+    return this.plannerEvents()
+      .filter((event) => this.formatDateKey(event.date as Date) === key)
+      .map((event) => ({ ...event, date: event.date as Date }))
+      .sort((a, b) => {
+        if (this.viewMode() === 'byTask') {
+          return this.slotOrderScore(a) - this.slotOrderScore(b);
+        }
+
+        const firstSlotA = this.earliestSlot(a);
+        const firstSlotB = this.earliestSlot(b);
+        return firstSlotA.getTime() - firstSlotB.getTime();
+      });
+  }
+
+  protected formattedTime(date: Date, time: string): string {
+    const [hours, minutes] = time.split(':').map(Number);
+    const copy = new Date(date);
+    copy.setHours(hours, minutes, 0, 0);
+    return copy.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  }
+
+  protected crewName(crewId: string): string {
+    return this.crewMembers().find((member) => member.id === crewId)?.name ??
+      'Unknown crew';
+  }
+
+  protected getVehicle(vehicleId: string): Vehicle | undefined {
+    return this.vehicles().find((vehicle) => vehicle.id === vehicleId);
+  }
+
+  protected toggleView(mode: 'byTask' | 'byTime'): void {
+    this.viewMode.set(mode);
+  }
+
+  protected adjustWeek(by: number): void {
+    const updated = this.addDays(this.selectedWeekStart(), by * 7);
+    this.selectedWeekStart.set(updated);
+  }
+
+  protected slotOrder(slots: PlannerSlot[]): PlannerSlot[] {
+    const orderedKeys: PlannerSlot['key'][] = ['packIn', 'rehearsal', 'show', 'packOut'];
+    if (this.viewMode() === 'byTask') {
+      return [...slots].sort(
+        (a, b) => orderedKeys.indexOf(a.key) - orderedKeys.indexOf(b.key),
+      );
+    }
+
+    return [...slots].sort((a, b) => this.timeToMinutes(a.start) - this.timeToMinutes(b.start));
+  }
+
+  protected warningForEvent(eventId: string): EventWarnings {
+    return (
+      this.eventWarnings().get(eventId) ?? { crewConflicts: [], vehicleAlerts: [] }
+    );
+  }
+
+  private slotOrderScore(event: PlannerEvent & { date: Date }): number {
+    const priority = ['packIn', 'rehearsal', 'show', 'packOut'];
+    const firstSlot = this.slotOrder(event.slots)[0];
+    return priority.indexOf(firstSlot?.key ?? 'packIn');
+  }
+
+  private earliestSlot(event: PlannerEvent & { date: Date }): Date {
+    const [hours, minutes] = (this.slotOrder(event.slots)[0]?.start ?? '00:00')
+      .split(':')
+      .map(Number);
+    const when = new Date(event.date);
+    when.setHours(hours, minutes, 0, 0);
+    return when;
+  }
+
+  private detectCrewConflicts(
+    events: (PlannerEvent & { date?: Date })[],
+    warnings: Map<string, EventWarnings>,
+  ): void {
+    const crewSchedule = new Map<
+      string,
+      { eventId: string; slotLabel: string; start: Date; end: Date }
+    >();
+
+    for (const event of events) {
+      for (const slot of event.slots) {
+        for (const assignment of slot.crew) {
+          const start = this.combineDateAndTime(event.date as Date, slot.start);
+          const end = this.addMinutes(start, slot.durationMinutes);
+          const key = `${assignment.crewId}-${start.toISOString()}`;
+          crewSchedule.set(key, {
+            eventId: event.id,
+            slotLabel: slot.label,
+            start,
+            end,
+          });
+        }
+      }
+    }
+
+    const groupedByCrew = new Map<string, typeof crewSchedule>();
+    for (const [key, entry] of crewSchedule.entries()) {
+      const crewId = key.split('-')[0];
+      const group = groupedByCrew.get(crewId) ?? new Map();
+      group.set(key, entry);
+      groupedByCrew.set(crewId, group);
+    }
+
+    const eventsById = new Map(events.map((event) => [event.id, event]));
+
+    for (const [crewId, assignments] of groupedByCrew) {
+      const sorted = Array.from(assignments.values()).sort(
+        (a, b) => a.start.getTime() - b.start.getTime(),
+      );
+
+      for (let i = 0; i < sorted.length - 1; i++) {
+        const current = sorted[i];
+        const next = sorted[i + 1];
+
+        if (current.end > next.start) {
+          const crewName = this.crewName(crewId);
+          const currentEvent = eventsById.get(current.eventId);
+          const nextEvent = eventsById.get(next.eventId);
+
+          const description = `${crewName} overlaps ${currentEvent?.title} (${current.slotLabel}) and ${nextEvent?.title} (${next.slotLabel}) at ${current.start.toLocaleTimeString([], {
+            hour: 'numeric',
+            minute: '2-digit',
+          })}`;
+
+          warnings.get(current.eventId)?.crewConflicts.push(description);
+          warnings.get(next.eventId)?.crewConflicts.push(description);
+        }
+      }
+    }
+  }
+
+  private timeToMinutes(time: string): number {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
+  }
+
+  private formatDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+  }
+
+  private addDays(date: Date, days: number): Date {
+    const copy = new Date(date);
+    copy.setDate(copy.getDate() + days);
+    return copy;
+  }
+
+  private addMinutes(date: Date, minutes: number): Date {
+    return new Date(date.getTime() + minutes * 60 * 1000);
+  }
+
+  private getStartOfWeek(date: Date): Date {
+    const day = date.getDay();
+    const diff = (day === 0 ? -6 : 1) - day;
+    return this.addDays(date, diff);
+  }
+
+  private combineDateAndTime(date: Date, time: string): Date {
+    const [hours, minutes] = time.split(':').map(Number);
+    const copy = new Date(date);
+    copy.setHours(hours, minutes, 0, 0);
+    return copy;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new crew planner page showing week-by-week staffing and vehicles
- highlight crew overlaps and upcoming or expired WOF dates
- allow toggling between pack-in grouping and chronological timeline per day

## Testing
- npm run lint -- --max-warnings=0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eadbd6a488323a045f52b18b120dc)