### PR TITLE
Refine xmas layout spacing and messaging overlay

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,9 +1,25 @@
-import { Routes } from '@angular/router';
+import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { CanMatchFn, Routes } from '@angular/router';
 import { HomeComponent } from './home/home-component/home-component';
 import { NotFoundComponent } from './shared/not-found-component/not-found-component';
 import { authGuard } from './auth/auth.guard';
 
+const xmasSubdomainMatcher: CanMatchFn = () => {
+  const platformId = inject(PLATFORM_ID);
+
+  if (!isPlatformBrowser(platformId)) return false;
+
+  return window.location.hostname.toLowerCase().includes('xmas.');
+};
+
 export const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    canMatch: [xmasSubdomainMatcher],
+    redirectTo: 'xmas',
+  },
   {
     path: 'login',
     loadComponent: () =>
@@ -23,6 +39,12 @@ export const routes: Routes = [
     component: HomeComponent,
     title: 'Cue RMS',
     canActivate: [authGuard],
+  },
+  {
+    path: 'xmas',
+    loadComponent: () =>
+      import('./xmas/xmas.component').then((m) => m.XmasComponent),
+    title: 'Merry Christmas | Cue RMS',
   },
   {
     path: 'home',

--- a/src/app/xmas/xmas.component.html
+++ b/src/app/xmas/xmas.component.html
@@ -1,0 +1,96 @@
+<div class="xmas-page">
+  <div class="sky">
+    <div
+      class="snowflake"
+      *ngFor="let flake of snowflakes; index as i"
+      [style.left.%]="(i * 8) % 100"
+      [style.animationDelay.s]="(i % 12) * 0.3"
+      [style.animationDuration.s]="8 + (i % 6)"
+    ></div>
+    <div class="aurora" aria-hidden="true"></div>
+  </div>
+
+  <div class="landscape">
+    <div class="hill back" aria-hidden="true"></div>
+    <div class="hill mid" aria-hidden="true"></div>
+    <div class="hill front" aria-hidden="true"></div>
+    <div class="string-lights" aria-hidden="true">
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+      <span class="bulb"></span>
+    </div>
+  </div>
+
+  <main class="content">
+    <section class="intro">
+      <p class="eyebrow">xmas.cue-rms.com</p>
+      <h1>Winter Wonderland Surprise</h1>
+      <p class="lede">
+        Ten presents are hidden behind pine trees draped in Christmas lights. Click each one to reveal its message.
+        Only one hides the real gift—can you spot it?
+      </p>
+    </section>
+
+    <section class="forest present-grid" aria-label="Christmas presents hidden by pine trees">
+      <div
+        class="tree-plot"
+        *ngFor="let present of presents; index as i"
+        [style.--peek-offset.px]="present.offset || 0"
+        [style.--peek-lift.px]="present.lift || -8"
+        [style.--peek-rotation.deg]="present.rotation || 0"
+        [style.--depth]="present.y || 0"
+        [style.left.%]="present.x || 0"
+        [style.top.%]="present.y || 0"
+        [style.zIndex]="200 - (present.y || 0)"
+      >
+        <button
+          class="present"
+          type="button"
+          (click)="openPresent(i)"
+          [class.opened]="present.opened"
+          [attr.aria-pressed]="present.opened"
+        >
+          <span class="tag">#{{ i + 1 }}</span>
+          <span class="lid"></span>
+          <span class="box"></span>
+          <span class="ribbon ribbon-horizontal"></span>
+          <span class="ribbon ribbon-vertical"></span>
+          <span class="sparkle" aria-hidden="true">✶</span>
+        </button>
+
+        <div class="tree" aria-hidden="true">
+          <div class="tree-topper">✷</div>
+          <div class="bough bough-1"></div>
+          <div class="bough bough-2"></div>
+          <div class="bough bough-3"></div>
+          <div class="trunk"></div>
+          <div class="lights">
+            <span class="light"></span>
+            <span class="light"></span>
+            <span class="light"></span>
+            <span class="light"></span>
+            <span class="light"></span>
+            <span class="light"></span>
+            <span class="light"></span>
+            <span class="light"></span>
+          </div>
+          <div class="snow-cap"></div>
+        </div>
+
+        <div class="snow-bank" aria-hidden="true"></div>
+      </div>
+
+      <div class="message-overlay" *ngIf="activeMessage">
+        <p [class.grand-reveal]="isGrandReveal">{{ activeMessage }}</p>
+        <p class="hint" *ngIf="!isGrandReveal">
+          Keep exploring the presents—someone tucked away a special surprise.
+        </p>
+      </div>
+    </section>
+  </main>
+</div>

--- a/src/app/xmas/xmas.component.scss
+++ b/src/app/xmas/xmas.component.scss
@@ -1,0 +1,567 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 20%, rgba(97, 219, 255, 0.25), transparent 28%),
+    radial-gradient(circle at 80% 10%, rgba(255, 182, 255, 0.25), transparent 24%),
+    linear-gradient(180deg, #071121 0%, #0f2641 35%, #1a4867 70%, #d5edf9 100%);
+  color: #f4fbff;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  position: relative;
+  overflow: hidden;
+}
+
+.xmas-page {
+  position: relative;
+  min-height: 100vh;
+}
+
+.sky {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.snowflake {
+  position: absolute;
+  top: -10vh;
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.6));
+  animation-name: fall, sway;
+  animation-timing-function: linear, ease-in-out;
+  animation-iteration-count: infinite;
+}
+
+.aurora {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 20%, rgba(107, 206, 255, 0.25), transparent 40%),
+    radial-gradient(circle at 65% 10%, rgba(255, 152, 255, 0.25), transparent 38%),
+    radial-gradient(circle at 80% 35%, rgba(136, 255, 199, 0.18), transparent 40%);
+  filter: blur(20px) saturate(120%);
+  opacity: 0.9;
+}
+
+@keyframes fall {
+  to {
+    transform: translateY(110vh);
+  }
+}
+
+@keyframes sway {
+  0% {
+    margin-left: -4px;
+  }
+  50% {
+    margin-left: 6px;
+  }
+  100% {
+    margin-left: -4px;
+  }
+}
+
+.landscape {
+  position: absolute;
+  bottom: -10px;
+  left: 0;
+  right: 0;
+  height: 44vh;
+  overflow: hidden;
+}
+
+.hill {
+  position: absolute;
+  inset: 0;
+  border-radius: 50% 50% 0 0;
+}
+
+.hill.back {
+  background: linear-gradient(180deg, rgba(240, 248, 255, 0.5) 0%, #dff1ff 70%);
+  transform: translateY(10%);
+}
+
+.hill.mid {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.7) 0%, #eff7ff 75%);
+  transform: translateY(16%);
+}
+
+.hill.front {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.85) 0%, #ffffff 80%);
+  transform: translateY(22%);
+  box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.14);
+}
+
+.string-lights {
+  position: absolute;
+  top: 18%;
+  left: -10%;
+  width: 120%;
+  height: 120px;
+  pointer-events: none;
+  background: radial-gradient(circle at 0 0, transparent 70%, rgba(0, 0, 0, 0.2) 72%),
+    radial-gradient(circle at 100% 0, transparent 70%, rgba(0, 0, 0, 0.2) 72%);
+  clip-path: polygon(0 40%, 10% 30%, 20% 45%, 30% 32%, 40% 48%, 52% 34%, 62% 52%, 72% 32%, 82% 48%, 92% 30%, 100% 44%, 100% 100%, 0 100%);
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.2));
+}
+
+.string-lights .bulb {
+  position: relative;
+  display: block;
+  width: 12px;
+  height: 12px;
+  background: #ff4d6d;
+  border-radius: 50%;
+  box-shadow: 30px 30px #ffd166, 60px -10px #5eead4, 90px 20px #a78bfa, 130px -5px #ffd166, 170px 28px #ff9f1c,
+    210px -8px #60a5fa, 250px 20px #fb7185, 290px -4px #34d399;
+  top: 24px;
+  left: 5%;
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.7));
+  animation: twinkle 2.6s ease-in-out infinite alternate;
+}
+
+@keyframes twinkle {
+  from {
+    opacity: 0.65;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(2px);
+  }
+}
+
+.content {
+  position: relative;
+  padding: 4rem clamp(1.5rem, 5vw, 3.5rem) 3rem;
+  text-align: center;
+  display: grid;
+  gap: 2rem;
+  place-items: center;
+}
+
+.eyebrow {
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  opacity: 0.85;
+  margin-bottom: 0.35rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  margin: 0.2rem 0 0.6rem;
+  text-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.lede {
+  max-width: 48rem;
+  margin: 0 auto;
+  color: #e6f3ff;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.present-grid {
+  position: relative;
+  width: min(1280px, 96vw);
+  min-height: clamp(620px, 68vh, 920px);
+  padding: clamp(1.25rem, 3vw, 2.5rem) clamp(0.75rem, 4vw, 2.5rem) 3.5rem;
+  margin: 0 auto;
+  isolation: isolate;
+}
+
+.forest {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0.06) 100%),
+    radial-gradient(circle at 18% 24%, rgba(255, 233, 109, 0.2) 0%, transparent 38%),
+    radial-gradient(circle at 78% 38%, rgba(255, 112, 138, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 32% 64%, rgba(111, 216, 255, 0.12) 0%, transparent 36%);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 28px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.22);
+  overflow: hidden;
+}
+
+.forest::before,
+.forest::after {
+  content: '';
+  position: absolute;
+  inset: 6% 8% auto;
+  height: 26%;
+  background: radial-gradient(circle at 10% 20%, rgba(255, 255, 255, 0.32) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.24) 0%, transparent 55%),
+    radial-gradient(circle at 70% 25%, rgba(255, 255, 255, 0.18) 0%, transparent 60%),
+    radial-gradient(circle at 90% 40%, rgba(255, 255, 255, 0.28) 0%, transparent 50%);
+  opacity: 0.45;
+  filter: blur(6px);
+  pointer-events: none;
+}
+
+.forest::after {
+  inset: auto 6% 10%;
+  height: 30%;
+  opacity: 0.35;
+  filter: blur(10px);
+}
+
+.tree-plot {
+  position: absolute;
+  width: clamp(146px, 14vw, 220px);
+  transform: translate(-50%, 0) scale(calc(0.8 + (var(--depth, 30) / 260)));
+  transform-origin: center bottom;
+  transition: transform 220ms ease, filter 220ms ease;
+  display: grid;
+  place-items: end center;
+  min-height: clamp(220px, 32vw, 340px);
+}
+
+.tree {
+  position: relative;
+  width: 100%;
+  max-width: 140px;
+  aspect-ratio: 1 / 1.2;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  filter: drop-shadow(0 14px 18px rgba(0, 0, 0, 0.28));
+  z-index: 3;
+}
+
+.tree-topper {
+  position: absolute;
+  top: 6%;
+  color: #ffe07a;
+  font-size: 1.2rem;
+  text-shadow: 0 0 12px rgba(255, 224, 122, 0.6);
+}
+
+.bough {
+  position: absolute;
+  width: 85%;
+  height: 36%;
+  background: linear-gradient(180deg, #1f9c6b 0%, #176347 70%);
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+  border-radius: 20px 20px 12px 12px;
+  filter: drop-shadow(0 10px 16px rgba(0, 0, 0, 0.25));
+}
+
+.bough-1 {
+  top: 8%;
+}
+
+.bough-2 {
+  top: 24%;
+  width: 92%;
+  height: 40%;
+  background: linear-gradient(180deg, #22b67b 0%, #0f4f3a 70%);
+}
+
+.bough-3 {
+  top: 44%;
+  width: 98%;
+  height: 44%;
+}
+
+.snow-cap {
+  position: absolute;
+  top: 24%;
+  width: 70%;
+  height: 22px;
+  background: linear-gradient(180deg, #ffffff 0%, #eaf6ff 80%);
+  clip-path: ellipse(50% 50% at 50% 50%);
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.16));
+  opacity: 0.9;
+}
+
+.trunk {
+  position: absolute;
+  bottom: 4%;
+  width: 22%;
+  height: 16%;
+  background: linear-gradient(180deg, #7a4d2a 0%, #5a3318 100%);
+  border-radius: 6px;
+  box-shadow: inset 0 -4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.lights {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+.light {
+  width: 9px;
+  height: 9px;
+  background: #ff4d6d;
+  border-radius: 50%;
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.8);
+  animation: glow 2s ease-in-out infinite alternate;
+}
+
+.lights .light:nth-child(2) {
+  transform: translate(-20px, -14px);
+  background: #5eead4;
+  animation-delay: 0.2s;
+}
+
+.lights .light:nth-child(3) {
+  transform: translate(18px, -12px);
+  background: #ffd166;
+  animation-delay: 0.4s;
+}
+
+.lights .light:nth-child(4) {
+  transform: translate(-26px, 12px);
+  background: #a78bfa;
+  animation-delay: 0.6s;
+}
+
+.lights .light:nth-child(5) {
+  transform: translate(24px, 10px);
+  background: #34d399;
+  animation-delay: 0.8s;
+}
+
+.lights .light:nth-child(6) {
+  transform: translate(-8px, 22px);
+  background: #fb7185;
+  animation-delay: 1s;
+}
+
+.lights .light:nth-child(7) {
+  transform: translate(6px, -26px);
+  background: #60a5fa;
+  animation-delay: 1.2s;
+}
+
+.lights .light:nth-child(8) {
+  transform: translate(0, 0);
+  background: #ffd166;
+  animation-delay: 1.4s;
+}
+
+.snow-bank {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 140%;
+  height: 60px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, #ffffff 70%);
+  border-radius: 50% 50% 20px 20px;
+  box-shadow: inset 0 10px 18px rgba(255, 255, 255, 0.5), 0 10px 20px rgba(0, 0, 0, 0.1);
+  z-index: 2;
+  opacity: 0.95;
+}
+
+@keyframes glow {
+  from {
+    opacity: 0.65;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
+.present {
+  position: absolute;
+  left: 50%;
+  bottom: 4px;
+  padding: 1.5rem 1rem 1rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  isolation: isolate;
+  transition: transform 160ms ease, filter 160ms ease, opacity 200ms ease;
+  width: 100%;
+  max-width: 124px;
+  transform: translate(-50%, var(--peek-lift, -8px)) translateX(var(--peek-offset, 0px)) rotate(var(--peek-rotation, 0deg));
+  z-index: 1;
+}
+
+.tree-plot:hover .present,
+.tree-plot:focus-within .present {
+  transform: translate(-50%, calc(var(--peek-lift, -8px) - 8px)) translateX(var(--peek-offset, 0px))
+    rotate(calc(var(--peek-rotation, 0deg) * 0.9));
+  filter: drop-shadow(0 16px 18px rgba(0, 0, 0, 0.2));
+}
+
+.present:focus-visible {
+  outline: 2px solid #ffeb6d;
+  outline-offset: 6px;
+}
+
+.lid,
+.box {
+  display: block;
+  border-radius: 10px;
+}
+
+.lid {
+  background: linear-gradient(120deg, #f72f5a, #ff7f51);
+  height: 28px;
+  width: 100%;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+  position: relative;
+  z-index: 2;
+}
+
+.box {
+  background: linear-gradient(135deg, #f8d250, #f2a93b);
+  height: 72px;
+  width: 100%;
+  margin-top: -6px;
+  box-shadow: inset 0 -10px 20px rgba(0, 0, 0, 0.18);
+}
+
+.ribbon {
+  position: absolute;
+  background: linear-gradient(180deg, #ffef9f 0%, #ffd24c 100%);
+}
+
+.ribbon-horizontal {
+  height: 12px;
+  width: 80%;
+  top: 36px;
+  left: 10%;
+  border-radius: 12px;
+}
+
+.ribbon-vertical {
+  width: 16px;
+  height: 100px;
+  left: calc(50% - 8px);
+  top: 8px;
+  border-radius: 12px;
+}
+
+.tag {
+  position: absolute;
+  top: -12px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #0a1b2a;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.18);
+}
+
+.sparkle {
+  position: absolute;
+  bottom: -12px;
+  right: 10px;
+  font-size: 1.1rem;
+  color: #ffef9f;
+  opacity: 0;
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.present.opened .lid {
+  transform: translateY(-26px) rotate(-3deg);
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.25);
+}
+
+.present.opened .sparkle {
+  opacity: 1;
+  transform: translateY(-6px) scale(1.1);
+}
+
+.message-overlay {
+  position: absolute;
+  inset: 6% auto auto 50%;
+  transform: translateX(-50%);
+  width: min(78%, 720px);
+  background: rgba(11, 30, 48, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 20px;
+  padding: 1.25rem;
+  box-shadow: 0 16px 26px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(12px);
+  z-index: 24;
+}
+
+.message-overlay p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.message-overlay .grand-reveal {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #ffe07a;
+}
+
+.hint {
+  margin-top: 0.65rem;
+  color: #d9e8f5;
+}
+
+@media (max-width: 1200px) {
+  .present-grid {
+    min-height: clamp(620px, 70vh, 860px);
+  }
+
+  .tree-plot {
+    width: clamp(134px, 18vw, 200px);
+  }
+}
+
+@media (max-width: 1100px) {
+  .present-grid {
+    width: min(1180px, 98vw);
+    padding: 1.25rem clamp(1rem, 4vw, 2rem) 3rem;
+  }
+
+  .message-overlay {
+    inset: 4% 1.25rem auto 1.25rem;
+    transform: none;
+    width: auto;
+  }
+
+  .tree-plot {
+    width: clamp(128px, 20vw, 190px);
+  }
+}
+
+@media (max-width: 900px) {
+  .present-grid {
+    min-height: 740px;
+  }
+
+  .tree-plot {
+    width: clamp(122px, 24vw, 180px);
+  }
+}
+
+@media (max-width: 640px) {
+  .present-grid {
+    min-height: 840px;
+    padding: 1.25rem 1rem 2.75rem;
+  }
+
+  .tree-plot {
+    width: clamp(118px, 32vw, 160px);
+  }
+
+  .message-overlay {
+    inset: 3% 0.75rem auto 0.75rem;
+    transform: none;
+  }
+
+  .lid {
+    height: 24px;
+  }
+
+  .box {
+    height: 64px;
+  }
+}

--- a/src/app/xmas/xmas.component.ts
+++ b/src/app/xmas/xmas.component.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface Present {
+  message: string;
+  special?: boolean;
+  opened?: boolean;
+  offset?: number;
+  lift?: number;
+  rotation?: number;
+  x?: number;
+  y?: number;
+}
+
+@Component({
+  selector: 'app-xmas',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './xmas.component.html',
+  styleUrls: ['./xmas.component.scss'],
+})
+export class XmasComponent {
+  snowflakes = Array.from({ length: 120 }, (_, index) => index);
+
+  presents: Present[] = [
+    { message: "Haha you thought this had a present, try another one.", offset: -44, lift: -10, rotation: -8, x: 12, y: 14 },
+    { message: "Nope, just more tinsel in this one. Keep hunting!", offset: 32, lift: -6, rotation: 5, x: 30, y: 20 },
+    { message: "Rudolph ate the gift in here. Maybe the next box?", offset: -16, lift: -4, rotation: -3, x: 55, y: 16 },
+    { message: "Santa said this one is only filled with giggles.", offset: 46, lift: -14, rotation: 7, x: 76, y: 22 },
+    { message: "Plot twist: it's empty wrapping paper. Next!", offset: -52, lift: -12, rotation: -6, x: 18, y: 38 },
+    { message: "Elves are on break, so this box is a decoy.", offset: 22, lift: -8, rotation: 4, x: 42, y: 34 },
+    { message: "This one contains... dramatic suspense. Keep going!", offset: -28, lift: -10, rotation: -5, x: 64, y: 36 },
+    { message: "Almost there! But this gift took a holiday.", offset: 40, lift: -10, rotation: 6, x: 86, y: 34 },
+    { message: "Close! This present is just jingling bells.", offset: -18, lift: -8, rotation: -4, x: 34, y: 56 },
+    {
+      message:
+        "Merry Christmas Mum & Dad, TeAna and I have booked you in for a nice meal at the Central Fire Station Bistro in Napier, we hope you enjoy (it's got good reviews lol). Love you guys!",
+      special: true,
+      offset: 28,
+      lift: -6,
+      rotation: 5,
+      x: 64,
+      y: 58,
+    },
+  ];
+
+  activeMessage = '';
+  isGrandReveal = false;
+
+  openPresent(index: number): void {
+    const present = this.presents[index];
+    present.opened = true;
+    this.activeMessage = present.message;
+    this.isGrandReveal = !!present.special;
+  }
+}


### PR DESCRIPTION
## Summary
- spread tree and present positions further across the scene and enlarge the forest canvas for a dotted layout
- move reveal copy into an in-scene overlay so messages stay within the viewing area on all devices
- adjust sizing and spacing breakpoints to improve responsiveness, including large tablets

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b164828488323993e9492c883ff1d)